### PR TITLE
feat: add AsciiDoc rendering and legal pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,22 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
+  STANDARDS_PATH: ${{ github.workspace }}/standards
 
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout website
         uses: actions/checkout@v4
+
+      - name: Checkout standards repository
+        uses: actions/checkout@v4
+        with:
+          repository: sipmorg/standards
+          path: standards
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,8 +49,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build with Vite
+      - name: Build site (includes standards JSON generation)
         run: npm run build
+        env:
+          STANDARDS_PATH: ${{ env.STANDARDS_PATH }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sipm-website",
       "version": "0.1.0",
       "dependencies": {
+        "@asciidoctor/core": "^3.0.4",
         "@unhead/vue": "^2.1.4",
         "vite-ssg": "^28.3.0",
         "vue": "^3.5.13",
@@ -57,6 +58,33 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@asciidoctor/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asciidoctor/opal-runtime": "3.0.1",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz",
+      "integrity": "sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "8.1.0",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -1241,6 +1269,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1248,6 +1282,15 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -1452,6 +1495,12 @@
         }
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1464,6 +1513,26 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/hookable": {
@@ -1539,6 +1608,23 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -1632,6 +1718,18 @@
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
     },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1664,6 +1762,15 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/param-case": {
@@ -1982,6 +2089,15 @@
         "url": "https://github.com/sponsors/harlan-zw"
       }
     },
+    "node_modules/unxhr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.11"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
@@ -2177,6 +2293,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite-ssg build",
+    "build": "npm run build:standards && vite-ssg build",
+    "build:standards": "node scripts/build-standards.js",
     "preview": "vite preview",
     "ssg": "vite-ssg build"
   },
   "dependencies": {
+    "@asciidoctor/core": "^3.0.4",
     "@unhead/vue": "^2.1.4",
     "vite-ssg": "^28.3.0",
     "vue": "^3.5.13",

--- a/public/content/standards/SIPM-0001.json
+++ b/public/content/standards/SIPM-0001.json
@@ -1,0 +1,475 @@
+{
+  "id": "SIPM-0001",
+  "title": "Terminology for Phytomedicine",
+  "attributes": {
+    "docnumber": "0001",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Terminology for Phytomedicine",
+    "title-part-en": "General vocabulary",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Terminology and Nomenclature",
+    "library-ics": "01.040.11;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_phytomedicine\">3.1. phytomedicine</a></li>\n<li><a href=\"#_medicinal_plant\">3.2. medicinal plant</a></li>\n<li><a href=\"#_botanical_drug_product\">3.3. botanical drug product</a></li>\n<li><a href=\"#_herbal_preparation\">3.4. herbal preparation</a></li>\n<li><a href=\"#_herbal_substance\">3.5. herbal substance</a></li>\n<li><a href=\"#_active_pharmaceutical_ingredient\">3.6. active pharmaceutical ingredient</a></li>\n<li><a href=\"#_marker_compound\">3.7. marker compound</a></li>\n<li><a href=\"#_active_marker_compound\">3.8. active marker compound</a></li>\n<li><a href=\"#_characteristic_constituent\">3.9. characteristic constituent</a></li>\n<li><a href=\"#_standardized_extract\">3.10. standardized extract</a></li>\n<li><a href=\"#_quantified_extract\">3.11. quantified extract</a></li>\n<li><a href=\"#_native_extract\">3.12. native extract</a></li>\n<li><a href=\"#_processed_extract\">3.13. processed extract</a></li>\n<li><a href=\"#_extraction\">3.14. extraction</a></li>\n<li><a href=\"#_extraction_solvent\">3.15. extraction solvent</a></li>\n<li><a href=\"#_extraction_yield\">3.16. extraction yield</a></li>\n<li><a href=\"#_phytochemistry\">3.17. phytochemistry</a></li>\n<li><a href=\"#_pharmacognosy\">3.18. pharmacognosy</a></li>\n<li><a href=\"#_plant_part\">3.19. plant part</a></li>\n<li><a href=\"#_botanical_identification\">3.20. botanical identification</a></li>\n<li><a href=\"#_adulteration\">3.21. adulteration</a></li>\n<li><a href=\"#_contamination\">3.22. contamination</a></li>\n<li><a href=\"#_quality_control\">3.23. quality control</a></li>\n<li><a href=\"#_stability\">3.24. stability</a></li>\n<li><a href=\"#_shelf_life\">3.25. shelf life</a></li>\n<li><a href=\"#_good_agricultural_and_collection_practices\">3.26. good agricultural and collection practices</a></li>\n<li><a href=\"#_voucher_specimen\">3.27. voucher specimen</a></li>\n<li><a href=\"#_botanical_reference_material\">3.28. botanical reference material</a></li>\n<li><a href=\"#_therapeutic_indication\">3.29. therapeutic indication</a></li>\n<li><a href=\"#_contraindication\">3.30. contraindication</a></li>\n<li><a href=\"#_traditional_use\">3.31. traditional use</a></li>\n<li><a href=\"#_well_established_use\">3.32. well-established use</a></li>\n<li><a href=\"#_safety\">3.33. safety</a></li>\n<li><a href=\"#_efficacy\">3.34. efficacy</a></li>\n<li><a href=\"#_pharmacovigilance\">3.35. pharmacovigilance</a></li>\n<li><a href=\"#_herbal_drug_interaction\">3.36. herbal-drug interaction</a></li>\n</ul>\n</li>\n<li><a href=\"#vocabulary\">4. Additional vocabulary</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_extraction_and_processing\">4.1. Extraction and processing</a></li>\n<li><a href=\"#_quality_and_testing\">4.2. Quality and testing</a></li>\n<li><a href=\"#_dosage_forms\">4.3. Dosage forms</a></li>\n<li><a href=\"#_biological_and_cultivation\">4.4. Biological and cultivation</a></li>\n<li><a href=\"#_regulatory_and_classification\">4.5. Regulatory and classification</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 1,\n<em>Terminology and Nomenclature</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0001.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0001 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The field of phytomedicine encompasses the study and therapeutic use of plant-\nderived substances for the prevention and treatment of disease. As interest in\nnatural health products has grown globally, the need for standardized terminology\nhas become increasingly important to ensure clear communication among\nresearchers, healthcare practitioners, regulators, manufacturers, and consumers.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes a comprehensive vocabulary for phytomedicine that\nprovides a foundation for consistent use of terms across scientific literature,\nregulatory documents, product labels, and clinical communications. The\nterminology presented here has been developed through consensus among\ninternational experts in pharmacognosy, botany, chemistry, pharmacology,\ntoxicology, and clinical medicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>The terminology in this document is organized into two main sections:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clause 3 defines core concepts that are essential for understanding\nphytomedicine and its related fields</p>\n</li>\n<li>\n<p>Clause 4 provides additional vocabulary for specific domains within\nphytomedicine</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to serve as a reference for authors of scientific\npapers, developers of regulatory guidelines, manufacturers of phytomedicine\nproducts, and healthcare professionals who recommend or prescribe phytomedicines.</p>\n</div>\n<div class=\"paragraph\">\n<p>The development of this terminology standard reflects SIPM&#8217;s commitment to\nadvancing the scientific basis of phytomedicine while respecting traditional\nknowledge systems. The definitions provided here are designed to be precise\nenough for scientific use while remaining accessible to diverse stakeholders\nin the phytomedicine community.</p>\n</div>\n<div class=\"paragraph\">\n<p>Future revisions of this document will incorporate new terms as the field\nevolves and will refine existing definitions based on scientific advances and\nfeedback from users of the standard.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document defines terms and establishes a vocabulary for the field of\nphytomedicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Scientific research and publication in phytomedicine</p>\n</li>\n<li>\n<p>Development and communication of regulatory requirements</p>\n</li>\n<li>\n<p>Manufacturing, quality control, and quality assurance of phytomedicine products</p>\n</li>\n<li>\n<p>Clinical practice and patient communication</p>\n</li>\n<li>\n<p>Education and training in phytomedicine and related fields</p>\n</li>\n<li>\n<p>Trade and commerce of phytomedicine products and raw materials</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Detailed taxonomic classification of medicinal plants (addressed in\nSIPM-0002)</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Clinical protocols (addressed in SIPM-0400 series)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The terms defined in this document are intended to be used in conjunction with\nother SIPM standards and may be referenced by external standards and regulatory\ndocuments.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"WHOGMP\"></a>[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</p>\n</li>\n<li>\n<p><a id=\"WHOTERM\"></a>[WHO International Standard Terminologies on Traditional Medicine in the Western Pacific Region]</p>\n</li>\n<li>\n<p><a id=\"ICHQ3R8\"></a>[ICH Q3(R8) Guideline for Elemental Impurities]</p>\n</li>\n<li>\n<p><a id=\"ISO9000\"></a>[ISO 9000:2015]</p>\n</li>\n<li>\n<p><a id=\"ISO11095\"></a>[ISO 11095:1996]</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_phytomedicine\">3.1. phytomedicine</h3>\n<div class=\"paragraph\">\n<p>alt:[herbal medicine]\nalt:[plant medicine]</p>\n</div>\n<div class=\"paragraph\">\n<p>medicinal product whose active ingredients are exclusively derived from one or\nmore plants, algae, fungi, or lichens in processed or unprocessed form</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 1: Phytomedicines may contain plant parts, plant juices, plant extracts,\nor purified compounds isolated from plants.</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 2: In some regulatory contexts, the term \"herbal medicinal product\" is\nused synonymously.</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#WHOTERM\">page 35</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_medicinal_plant\">3.2. medicinal plant</h3>\n<div class=\"paragraph\">\n<p>plant species that contains substances which can be used for therapeutic\npurposes or which are precursors for the synthesis of useful drugs</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMedicinal plants may be used in their whole form or as a source of\nisolated compounds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_drug_product\">3.3. botanical drug product</h3>\n<div class=\"paragraph\">\n<p>alt:[botanical drug]</p>\n</div>\n<div class=\"paragraph\">\n<p>finished product that contains a botanical drug substance, generally as the\nactive ingredient, and is intended to diagnose, cure, treat, mitigate, or\nprevent disease</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nThis term is commonly used in regulatory contexts, particularly in the\nUnited States.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#USPNF\">[United States Pharmacopeia - National Formulary]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_preparation\">3.4. herbal preparation</h3>\n<div class=\"paragraph\">\n<p>preparation obtained by subjecting herbal substances to treatments such as\nextraction, distillation, expression, fractionation, purification,\nconcentration, or fermentation</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nHerbal preparations include, but are not limited to, comminuted or\npowdered herbal substances, tinctures, extracts, essential oils, expressed\njuices, and processed exudates.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#EP10th\">[European Pharmacopoeia 10th Edition]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_substance\">3.5. herbal substance</h3>\n<div class=\"paragraph\">\n<p>alt:[herbal drug]\nalt:[plant material]</p>\n</div>\n<div class=\"paragraph\">\n<p>whole, fragmented, or cut plants, parts of plants, algae, fungi, or lichen in\nan unprocessed state, usually in dried form but sometimes fresh</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCertain exudates that have not been subjected to a specific treatment are\nalso considered herbal substances.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#EP10th\">[European Pharmacopoeia 10th Edition]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_active_pharmaceutical_ingredient\">3.6. active pharmaceutical ingredient</h3>\n<div class=\"paragraph\">\n<p>alt:[API]\nalt:[active ingredient]</p>\n</div>\n<div class=\"paragraph\">\n<p>substance or mixture of substances intended to be used in the manufacture of a\ndrug product and that, when used in the production of a drug, becomes an active\ningredient in the drug product</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 1: In phytomedicine, the API may be a single compound or a defined\nmixture of compounds derived from the plant material.</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 2: For some phytomedicines, the active constituents are not fully\ncharacterized, and the API is defined as the herbal preparation or its\nstandardized extract.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_marker_compound\">3.7. marker compound</h3>\n<div class=\"paragraph\">\n<p>chemical constituent or group of constituents characteristic of a particular\nplant species or plant part, used for identification, quality assessment, or\nstandardization purposes</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMarker compounds are not necessarily responsible for the therapeutic\nactivity of the phytomedicine.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_active_marker_compound\">3.8. active marker compound</h3>\n<div class=\"paragraph\">\n<p>marker compound that contributes to the therapeutic activity of a phytomedicine</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nActive markers may be used for standardization when the full mechanism\nof action is not understood.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_characteristic_constituent\">3.9. characteristic constituent</h3>\n<div class=\"paragraph\">\n<p>alt：【diagnostic marker】</p>\n</div>\n<div class=\"paragraph\">\n<p>chemical constituent that is unique to, or highly characteristic of, a\nparticular plant species and can be used for authentication purposes</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_standardized_extract\">3.10. standardized extract</h3>\n<div class=\"paragraph\">\n<p>herbal preparation that has been processed to contain a defined amount of one\nor more specified constituents, typically expressed as a percentage or range</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nStandardization may be based on active markers, analytical markers, or\ncharacteristic constituents.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quantified_extract\">3.11. quantified extract</h3>\n<div class=\"paragraph\">\n<p>herbal preparation with defined content ranges for one or more groups of\nconstituents</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nUnlike standardized extracts, quantified extracts specify acceptable\nranges rather than target values.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_native_extract\">3.12. native extract</h3>\n<div class=\"paragraph\">\n<p>alt:[genuine extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>extract that contains only constituents naturally present in the source\nmaterial, without added excipients or further processing that would alter its\ncomposition</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_processed_extract\">3.13. processed extract</h3>\n<div class=\"paragraph\">\n<p>extract that has undergone additional processing steps beyond initial\nextraction, which may include purification, concentration, drying, or addition\nof excipients</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction\">3.14. extraction</h3>\n<div class=\"paragraph\">\n<p>process of separating active or desirable constituents from plant material using\na solvent or other physical or chemical means</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_solvent\">3.15. extraction solvent</h3>\n<div class=\"paragraph\">\n<p>solvent used to extract desired constituents from plant material</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon extraction solvents include water, ethanol, methanol,\nsupercritical carbon dioxide, and various oils.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_yield\">3.16. extraction yield</h3>\n<div class=\"paragraph\">\n<p>alt:[extract yield]</p>\n</div>\n<div class=\"paragraph\">\n<p>amount of extract obtained from a specified amount of starting plant material,\ntypically expressed as a percentage by mass</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_phytochemistry\">3.17. phytochemistry</h3>\n<div class=\"paragraph\">\n<p>branch of chemistry dealing with the chemical constituents of plants and their\nproperties, reactions, and methods of isolation and identification</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacognosy\">3.18. pharmacognosy</h3>\n<div class=\"paragraph\">\n<p>study of medicines derived from natural sources, including plants, animals,\nand microorganisms, encompassing their physical, chemical, biochemical, and\nbiological properties</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_plant_part\">3.19. plant part</h3>\n<div class=\"paragraph\">\n<p>alt:[plant organ]\nalt:[medicinal plant part]</p>\n</div>\n<div class=\"paragraph\">\n<p>specific organ or portion of a plant that is used for medicinal purposes</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nRoot, rhizome, bark, leaf, flower, fruit, seed, whole herb.\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_identification\">3.20. botanical identification</h3>\n<div class=\"paragraph\">\n<p>process of determining the identity of a plant material to species level,\nincluding verification of the plant part used</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_adulteration\">3.21. adulteration</h3>\n<div class=\"paragraph\">\n<p>intentional addition of non-authentic material or the substitution of authentic\nmaterial with inferior or harmful substances</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nAdulteration may involve addition of synthetic drugs, other plant\nspecies, or contaminants.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_contamination\">3.22. contamination</h3>\n<div class=\"paragraph\">\n<p>unintended presence of harmful or undesirable substances in plant material or\nherbal preparations</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nHeavy metals, pesticides, mycotoxins, microorganisms, foreign plant material.\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_control\">3.23. quality control</h3>\n<div class=\"paragraph\">\n<p>operational techniques and activities used to fulfill requirements for quality</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nIn phytomedicine, quality control typically includes identity testing,\npurity testing, potency assessment, and stability testing.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ISO9000\">clause 3.3.7</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_stability\">3.24. stability</h3>\n<div class=\"paragraph\">\n<p>capacity of a phytomedicine product to remain within established specifications\nfor identity, strength, quality, and purity throughout its shelf life</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_shelf_life\">3.25. shelf life</h3>\n<div class=\"paragraph\">\n<p>alt:[expiration dating period]</p>\n</div>\n<div class=\"paragraph\">\n<p>time period during which a phytomedicine product is expected to remain within\napproved shelf-life specifications, provided it is stored under the conditions\ndefined on the container label</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_good_agricultural_and_collection_practices\">3.26. good agricultural and collection practices</h3>\n<div class=\"paragraph\">\n<p>alt:[GACP]</p>\n</div>\n<div class=\"paragraph\">\n<p>practices addressing quality assurance and control in the production and\ncollection of medicinal plants</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nGACP covers cultivation, harvesting, post-harvest processing, storage,\nand transportation.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#WHOGMP\">[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_voucher_specimen\">3.27. voucher specimen</h3>\n<div class=\"paragraph\">\n<p>preserved sample of plant material that serves as a permanent record of the\nsource material used in scientific studies or commercial production</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nVoucher specimens enable verification of botanical identity and are\ntypically deposited in recognized herbaria.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_reference_material\">3.28. botanical reference material</h3>\n<div class=\"paragraph\">\n<p>alt:[BRM]</p>\n</div>\n<div class=\"paragraph\">\n<p>well-characterized material used as a standard for comparison in identity\ntesting and quality control</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nBotanical reference materials may be whole plant material, plant parts,\nor processed extracts.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_therapeutic_indication\">3.29. therapeutic indication</h3>\n<div class=\"paragraph\">\n<p>medical condition or disease state for which a phytomedicine is intended to\nbe used</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_contraindication\">3.30. contraindication</h3>\n<div class=\"paragraph\">\n<p>condition or factor that serves as a reason to withhold a certain medical\ntreatment due to the harm that it would cause the patient</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traditional_use\">3.31. traditional use</h3>\n<div class=\"paragraph\">\n<p>use of a medicinal plant or phytomedicine based on accumulated knowledge and\nexperience over generations within a specific cultural context</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_well_established_use\">3.32. well-established use</h3>\n<div class=\"paragraph\">\n<p>use of a medicinal plant or phytomedicine that has been recognized for at\nleast 10 years within a specific jurisdiction with demonstrated safety and\nefficacy</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nWell-established use may be a basis for simplified regulatory approval\nin some jurisdictions.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_safety\">3.33. safety</h3>\n<div class=\"paragraph\">\n<p>absence of unacceptable risk of harm to human health under intended or\nforeseeable conditions of use</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_efficacy\">3.34. efficacy</h3>\n<div class=\"paragraph\">\n<p>ability of a phytomedicine to produce a beneficial effect under controlled\nconditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacovigilance\">3.35. pharmacovigilance</h3>\n<div class=\"paragraph\">\n<p>science and activities relating to the detection, assessment, understanding,\nand prevention of adverse effects or any other drug-related problems</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_drug_interaction\">3.36. herbal-drug interaction</h3>\n<div class=\"paragraph\">\n<p>alt:[herb-drug interaction]\nalt:[HD interaction]</p>\n</div>\n<div class=\"paragraph\">\n<p>modification of the effect of a drug when co-administered with a herbal\npreparation, or modification of the effect of a herbal preparation when\nco-administered with a drug</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nInteractions may result in increased or decreased drug effects,\nor new adverse reactions.\n</td>\n</tr>\n</table>\n</div>\n<table id=\"table-markers\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Marker compound classification</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 75%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Classification</th>\n<th class=\"tableblock halign-left valign-top\">Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Active marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that contributes to the therapeutic effect and is used for\n  standardization</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Analytical marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound used for identification and quantification purposes, not necessarily\n  therapeutically active</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Toxicity marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that indicates potential toxicity concerns</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Stability marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that degrades in a predictable manner and indicates product stability</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"vocabulary\">4. Additional vocabulary</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This clause provides additional vocabulary organized by domain.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_and_processing\">4.1. Extraction and processing</h3>\n<div class=\"sect3\">\n<h4 id=\"_maceration\">4.1.1. maceration</h4>\n<div class=\"paragraph\">\n<p>extraction process in which plant material is soaked in a solvent at room\ntemperature for an extended period</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_percolation\">4.1.2. percolation</h4>\n<div class=\"paragraph\">\n<p>extraction process in which solvent passes through a column or bed of plant\nmaterial, typically under gravity or low pressure</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_decoction\">4.1.3. decoction</h4>\n<div class=\"paragraph\">\n<p>extraction process involving boiling plant material in water</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nDecoction is traditionally used for hard plant materials such as roots,\nbark, and seeds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_infusion\">4.1.4. infusion</h4>\n<div class=\"paragraph\">\n<p>extraction process in which plant material is steeped in hot or cold water\nwithout boiling</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nInfusion is traditionally used for delicate plant materials such as\nleaves and flowers.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_tincture\">4.1.5. tincture</h4>\n<div class=\"paragraph\">\n<p>alt:[alcoholic extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation obtained by maceration or percolation of plant material in\na mixture of alcohol and water</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTinctures are typically prepared at defined drug-to-extract ratios.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_fluid_extract\">4.1.6. fluid extract</h4>\n<div class=\"paragraph\">\n<p>alt:[liquid extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation containing the active constituents of plant material,\ntypically more concentrated than a tincture</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_dry_extract\">4.1.7. dry extract</h4>\n<div class=\"paragraph\">\n<p>solid extract obtained by removal of the extraction solvent, typically through\nevaporation or freeze-drying</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_soft_extract\">4.1.8. soft extract</h4>\n<div class=\"paragraph\">\n<p>alt:[semi-solid extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>extract with a viscous or semi-solid consistency, typically containing\nresidual moisture or solvent</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_drug_to_extract_ratio\">4.1.9. drug-to-extract ratio</h4>\n<div class=\"paragraph\">\n<p>alt:[DER]</p>\n</div>\n<div class=\"paragraph\">\n<p>ratio of the mass of starting plant material to the mass of the resulting\nextract</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nA 10:1 drug-to-extract ratio indicates that 10 kg of plant material yields\n1 kg of extract.\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_and_testing\">4.2. Quality and testing</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_testing\">4.2.1. identity testing</h4>\n<div class=\"paragraph\">\n<p>analytical procedures performed to confirm that a material is what it purports\nto be</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nIdentity testing may include macroscopic examination, microscopic\nanalysis, chromatographic fingerprinting, and spectroscopic methods.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_purity_testing\">4.2.2. purity testing</h4>\n<div class=\"paragraph\">\n<p>analytical procedures performed to determine the presence and amount of\nimpurities or contaminants</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_potency\">4.2.3. potency</h4>\n<div class=\"paragraph\">\n<p>measure of the biological activity or strength of a phytomedicine, typically\nexpressed relative to a reference standard</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_fingerprint\">4.2.4. fingerprint</h4>\n<div class=\"paragraph\">\n<p>chromatographic or spectroscopic pattern that is characteristic of a particular\nplant material or extract</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nFingerprints are used for identity confirmation and quality comparison.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_specification\">4.2.5. specification</h4>\n<div class=\"paragraph\">\n<p>list of tests, references to analytical procedures, and appropriate acceptance\ncriteria for a material</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ICHQ3r8\">[ICHQ3r8]</a></p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_dosage_forms\">4.3. Dosage forms</h3>\n<div class=\"sect3\">\n<h4 id=\"_oral_liquid\">4.3.1. oral liquid</h4>\n<div class=\"paragraph\">\n<p>alt:[liquid for oral use]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation intended for oral administration</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_tablet\">4.3.2. tablet</h4>\n<div class=\"paragraph\">\n<p>solid dosage form containing phytomedicine ingredients, usually prepared by\ncompression</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_capsule\">4.3.3. capsule</h4>\n<div class=\"paragraph\">\n<p>solid dosage form in which the phytomedicine ingredient is enclosed in a\nsoluble container, typically made of gelatin or plant-derived materials</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_topical_preparation\">4.3.4. topical preparation</h4>\n<div class=\"paragraph\">\n<p>alt:[preparation for dermal use]</p>\n</div>\n<div class=\"paragraph\">\n<p>preparation intended for application to the skin or mucous membranes</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_powdered_extract\">4.3.5. powdered extract</h4>\n<div class=\"paragraph\">\n<p>alt:[spray-dried extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>dry extract in powder form, typically produced by spray drying</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_biological_and_cultivation\">4.4. Biological and cultivation</h3>\n<div class=\"sect3\">\n<h4 id=\"_cultivation\">4.4.1. cultivation</h4>\n<div class=\"paragraph\">\n<p>practice of growing medicinal plants under controlled or semi-controlled\nconditions</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_wild_collection\">4.4.2. wild collection</h4>\n<div class=\"paragraph\">\n<p>alt:[wild harvesting]\nalt:[wild crafting]</p>\n</div>\n<div class=\"paragraph\">\n<p>gathering of medicinal plants from their natural habitat</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nWild collection requires sustainable practices to ensure species\nconservation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_sustainable_harvesting\">4.4.3. sustainable harvesting</h4>\n<div class=\"paragraph\">\n<p>collection of plant material in a manner that ensures the long-term survival\nof the species and its ecosystem</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSustainable harvesting considers regeneration rates, ecological impact,\nand biodiversity conservation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_good_agricultural_practices\">4.4.4. Good Agricultural Practices</h4>\n<div class=\"paragraph\">\n<p>alt:[GAP]</p>\n</div>\n<div class=\"paragraph\">\n<p>standards and practices for the production of medicinal plants under\ncontrolled agricultural conditions</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nGAP covers site selection, propagation, cultivation, plant protection,\nharvesting, and primary processing.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_regulatory_and_classification\">4.5. Regulatory and classification</h3>\n<div class=\"sect3\">\n<h4 id=\"_dietary_supplement\">4.5.1. dietary supplement</h4>\n<div class=\"paragraph\">\n<p>product intended to supplement the diet that contains one or more dietary\ningredients, including vitamins, minerals, herbs, or other botanicals</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nRegulatory classification of phytomedicines as dietary supplements varies\nby jurisdiction.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_traditional_herbal_medicinal_product\">4.5.2. traditional herbal medicinal product</h4>\n<div class=\"paragraph\">\n<p>alt:[THMP]</p>\n</div>\n<div class=\"paragraph\">\n<p>medicinal product whose active ingredients are exclusively herbal substances\nor herbal preparations, intended and designed for use without the supervision\nof a medical practitioner</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTraditional use of at least 30 years, including 15 years within the\nrelevant jurisdiction, is typically required for THMP status.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_health_claim\">4.5.3. health claim</h4>\n<div class=\"paragraph\">\n<p>statement that describes the relationship between a food or food component\nand a disease or health-related condition</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_structure_function_claim\">4.5.4. structure-function claim</h4>\n<div class=\"paragraph\">\n<p>statement that describes the role of a nutrient or dietary ingredient intended\nto affect the normal structure or function of the human body</p>\n</div>\n<table id=\"table-preparations\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Common herbal preparations and their characteristics</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 25%;\">\n<col style=\"width: 50%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Preparation type</th>\n<th class=\"tableblock halign-left valign-top\">Solvent/Method</th>\n<th class=\"tableblock halign-left valign-top\">Characteristics</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Tincture</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Alcohol/water mixture, maceration</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Liquid, typically 1:5 to 1:10 DER</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fluid extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Alcohol/water mixture, percolation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Liquid, typically 1:1 DER</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Dry extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Various solvents, evaporation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Solid powder, high concentration</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Soft extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Various solvents, partial evaporation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Viscous, contains residual solvent</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Essential oil</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Steam distillation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Volatile, aromatic liquid</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Expressed juice</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Mechanical pressing</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fresh plant liquid</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ISO3696\"></a>[ISO 3696:1987], Water for analytical laboratory use&#8201;&#8212;&#8201;Specification\nand test methods</p>\n</li>\n<li>\n<p><a id=\"ISO5725-1\"></a>[ISO 5725-1:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 1: General principles and definitions</p>\n</li>\n<li>\n<p><a id=\"ISO5725-2\"></a>[ISO 5725-2:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 2: Basic method for the determination\nof repeatability and reproducibility of a standard measurement method</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials], World\nHealth Organization, Geneva, 1998</p>\n</li>\n<li>\n<p><a id=\"WHOPHARM\"></a>[WHO Monographs on Selected Medicinal Plants], World Health\nOrganization, Geneva, Vols. 1-4</p>\n</li>\n<li>\n<p><a id=\"ESCP\"></a>[European Scientific Cooperative on Phytotherapy (ESCOP) Monographs],\nESCOP, Exeter, UK</p>\n</li>\n<li>\n<p>[<a id=\"BMABlumenthal\"></a>, <em>The ABC Clinical Guide to Herbs</em>.\nAmerican Botanical Council, Austin, TX, 2003</p>\n</li>\n<li>\n<p>[<a id=\"Bruneton\"></a>, <em>Pharmacognosy, Phytochemistry, Medicinal Plants</em>.\n2nd ed. Lavoisier Publishing, Paris, 1999</p>\n</li>\n<li>\n<p>[<a id=\"Evans\"></a>, <em>Trease and Evans' Pharmacognosy</em>. 15th ed.\nSaunders, Edinburgh, 2002</p>\n</li>\n<li>\n<p>[<a id=\"Heinrich\"></a>, <em>Fundamentals of Pharmacognosy and Phytotherapy</em>.\n2nd ed. Churchill Livingstone, Edinburgh, 2012</p>\n</li>\n<li>\n<p>[<a id=\"VanBreemen\"></a>, Developing standards for validating\nbotanical dietary supplements. <em>J. AOAC Int.</em> 2006, <strong>89</strong> (1) pp. 1-4</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_phytomedicine",
+          "title": "phytomedicine",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_medicinal_plant",
+          "title": "medicinal plant",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_drug_product",
+          "title": "botanical drug product",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_preparation",
+          "title": "herbal preparation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_substance",
+          "title": "herbal substance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_active_pharmaceutical_ingredient",
+          "title": "active pharmaceutical ingredient",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_marker_compound",
+          "title": "marker compound",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_active_marker_compound",
+          "title": "active marker compound",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_characteristic_constituent",
+          "title": "characteristic constituent",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_standardized_extract",
+          "title": "standardized extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_quantified_extract",
+          "title": "quantified extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_native_extract",
+          "title": "native extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_processed_extract",
+          "title": "processed extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction",
+          "title": "extraction",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction_solvent",
+          "title": "extraction solvent",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction_yield",
+          "title": "extraction yield",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_phytochemistry",
+          "title": "phytochemistry",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacognosy",
+          "title": "pharmacognosy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_plant_part",
+          "title": "plant part",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_identification",
+          "title": "botanical identification",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_adulteration",
+          "title": "adulteration",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_contamination",
+          "title": "contamination",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_quality_control",
+          "title": "quality control",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_stability",
+          "title": "stability",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_shelf_life",
+          "title": "shelf life",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_good_agricultural_and_collection_practices",
+          "title": "good agricultural and collection practices",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_voucher_specimen",
+          "title": "voucher specimen",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_reference_material",
+          "title": "botanical reference material",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_therapeutic_indication",
+          "title": "therapeutic indication",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_contraindication",
+          "title": "contraindication",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traditional_use",
+          "title": "traditional use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_well_established_use",
+          "title": "well-established use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_safety",
+          "title": "safety",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_efficacy",
+          "title": "efficacy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacovigilance",
+          "title": "pharmacovigilance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_drug_interaction",
+          "title": "herbal-drug interaction",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "vocabulary",
+      "title": "Additional vocabulary",
+      "level": 1,
+      "children": [
+        {
+          "id": "_extraction_and_processing",
+          "title": "Extraction and processing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_maceration",
+              "title": "maceration",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_percolation",
+              "title": "percolation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_decoction",
+              "title": "decoction",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_infusion",
+              "title": "infusion",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_tincture",
+              "title": "tincture",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_fluid_extract",
+              "title": "fluid extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_dry_extract",
+              "title": "dry extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_soft_extract",
+              "title": "soft extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_drug_to_extract_ratio",
+              "title": "drug-to-extract ratio",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_quality_and_testing",
+          "title": "Quality and testing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_testing",
+              "title": "identity testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_purity_testing",
+              "title": "purity testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_potency",
+              "title": "potency",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_fingerprint",
+              "title": "fingerprint",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_specification",
+              "title": "specification",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_dosage_forms",
+          "title": "Dosage forms",
+          "level": 2,
+          "children": [
+            {
+              "id": "_oral_liquid",
+              "title": "oral liquid",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_tablet",
+              "title": "tablet",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_capsule",
+              "title": "capsule",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_topical_preparation",
+              "title": "topical preparation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_powdered_extract",
+              "title": "powdered extract",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_biological_and_cultivation",
+          "title": "Biological and cultivation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_cultivation",
+              "title": "cultivation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_wild_collection",
+              "title": "wild collection",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_sustainable_harvesting",
+              "title": "sustainable harvesting",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_good_agricultural_practices",
+              "title": "Good Agricultural Practices",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_regulatory_and_classification",
+          "title": "Regulatory and classification",
+          "level": 2,
+          "children": [
+            {
+              "id": "_dietary_supplement",
+              "title": "dietary supplement",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_traditional_herbal_medicinal_product",
+              "title": "traditional herbal medicinal product",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_health_claim",
+              "title": "health claim",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_structure_function_claim",
+              "title": "structure-function claim",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Terminology for Phytomedicine\n:docnumber: 0001\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Terminology for Phytomedicine\n:title-part-en: General vocabulary\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 1\n:technical-committee: Terminology and Nomenclature\n:library-ics: 01.040.11;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-vocabulary.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/public/content/standards/SIPM-0002.json
+++ b/public/content/standards/SIPM-0002.json
@@ -1,0 +1,279 @@
+{
+  "id": "SIPM-0002",
+  "title": "Medicinal Fungi Taxonomy",
+  "attributes": {
+    "docnumber": "0002",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Medicinal Fungi Taxonomy and Nomenclature",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Fungi and Lichens",
+    "library-ics": "07.100.20;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_medicinal_fungus\">3.1. medicinal fungus</a></li>\n<li><a href=\"#_basidiomycete\">3.2. basidiomycete</a></li>\n<li><a href=\"#_ascomycete\">3.3. ascomycete</a></li>\n<li><a href=\"#_fruiting_body\">3.4. fruiting body</a></li>\n<li><a href=\"#_mycelium\">3.5. mycelium</a></li>\n<li><a href=\"#_sclerotium\">3.6. sclerotium</a></li>\n<li><a href=\"#_spore\">3.7. spore</a></li>\n<li><a href=\"#_anamorph\">3.8. anamorph</a></li>\n<li><a href=\"#_teleomorph\">3.9. teleomorph</a></li>\n<li><a href=\"#_holomorph\">3.10. holomorph</a></li>\n<li><a href=\"#_species_complex\">3.11. species complex</a></li>\n<li><a href=\"#_strain\">3.12. strain</a></li>\n</ul>\n</li>\n<li><a href=\"#taxonomy\">4. Taxonomic classification</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_general_requirements\">4.1. General requirements</a></li>\n<li><a href=\"#_taxonomic_hierarchy\">4.2. Taxonomic hierarchy</a></li>\n<li><a href=\"#_scientific_names\">4.3. Scientific names</a></li>\n<li><a href=\"#_synonyms_and_deprecated_names\">4.4. Synonyms and deprecated names</a></li>\n</ul>\n</li>\n<li><a href=\"#nomenclature\">5. Nomenclature standards</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_general_requirements_2\">5.1. General requirements</a></li>\n<li><a href=\"#_documentation_requirements\">5.2. Documentation requirements</a></li>\n<li><a href=\"#_product_labeling\">5.3. Product labeling</a></li>\n<li><a href=\"#_quality_control_documentation\">5.4. Quality control documentation</a></li>\n<li><a href=\"#_species_specific_requirements\">5.5. Species-specific requirements</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 2,\n<em>Fungi and Lichens</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0002.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0002 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>Medicinal fungi have been used for therapeutic purposes across cultures for\nmillennia. In recent decades, scientific research has validated many traditional\nuses and identified bioactive compounds with significant pharmacological\nproperties. As the medicinal fungi industry grows, accurate taxonomy and\nstandardized nomenclature become essential for quality control, safety, and\nregulatory compliance.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes standards for the taxonomic classification and\nnomenclature of medicinal fungi used in phytomedicine and natural health\nproducts. It addresses the unique challenges of fungal taxonomy, including\nthe distinction between anamorph and teleomorph states, the complexity of\nfungal species complexes, and the need for consistent naming across scientific,\ncommercial, and regulatory contexts.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standards presented here are designed to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Ensure accurate identification of medicinal fungi species</p>\n</li>\n<li>\n<p>Promote consistent nomenclature in scientific and commercial contexts</p>\n</li>\n<li>\n<p>Facilitate communication between researchers, manufacturers, and regulators</p>\n</li>\n<li>\n<p>Support quality control and traceability throughout the supply chain</p>\n</li>\n<li>\n<p>Contribute to the conservation of medicinal fungi biodiversity</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to be used in conjunction with SIPM-0001 (Terminology\nfor Phytomedicine) and relevant analytical standards in the SIPM-0300 series.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the taxonomic classification and\nnomenclature of medicinal fungi used in phytomedicine and natural health\nproducts.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Scientific research and publication involving medicinal fungi</p>\n</li>\n<li>\n<p>Cultivation, collection, and trade of medicinal fungi raw materials</p>\n</li>\n<li>\n<p>Manufacturing and quality control of medicinal fungi products</p>\n</li>\n<li>\n<p>Regulatory submissions and compliance</p>\n</li>\n<li>\n<p>Education and training in mycology and phytomedicine</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Basidiomycetes (mushrooms, bracket fungi)</p>\n</li>\n<li>\n<p>Ascomycetes (morels, truffles, Cordyceps)</p>\n</li>\n<li>\n<p>Other fungi used for therapeutic purposes</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Detailed cultivation methods (addressed in SIPM-0200 series)</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Clinical protocols (addressed in SIPM-0400 series)</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICN\"></a>[International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code)]</p>\n</li>\n<li>\n<p><a id=\"ICNP\"></a>[International Code of Nomenclature of Prokaryotes]</p>\n</li>\n<li>\n<p><a id=\"IndexFungorum\"></a>[Index Fungorum Database]</p>\n</li>\n<li>\n<p><a id=\"MycoBank\"></a>[MycoBank Fungal Database]</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials]</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_medicinal_fungus\">3.1. medicinal fungus</h3>\n<div class=\"paragraph\">\n<p>alt:[medicinal mushroom]</p>\n</div>\n<div class=\"paragraph\">\n<p>fungal species that contains substances which can be used for therapeutic\npurposes or which are precursors for the synthesis of useful drugs</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_basidiomycete\">3.2. basidiomycete</h3>\n<div class=\"paragraph\">\n<p>member of the phylum Basidiomycota, characterized by the production of\nspores on a basidium</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon medicinal basidiomycetes include Reishi (Ganoderma lucidum),\nShiitake (Lentinula edodes), and Turkey Tail (Trametes versicolor).\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_ascomycete\">3.3. ascomycete</h3>\n<div class=\"paragraph\">\n<p>member of the phylum Ascomycota, characterized by the production of spores\nin an ascus</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon medicinal ascomycetes include Cordyceps (Cordyceps sinensis),\nMorel (Morchella spp.), and Chaga (Inonotus obliquus).\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_fruiting_body\">3.4. fruiting body</h3>\n<div class=\"paragraph\">\n<p>alt:[sporocarp]\nalt:[mushroom]</p>\n</div>\n<div class=\"paragraph\">\n<p>reproductive structure of a fungus that produces and disperses spores</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_mycelium\">3.5. mycelium</h3>\n<div class=\"paragraph\">\n<p>vegetative part of a fungus, consisting of a network of fine white filaments\n(hyphae)</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_sclerotium\">3.6. sclerotium</h3>\n<div class=\"paragraph\">\n<p>compact mass of hardened fungal mycelium containing food reserves, capable of\nremaining dormant for extended periods</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nThe sclerotium of Poria cocos (Fu Ling) is used medicinally.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_spore\">3.7. spore</h3>\n<div class=\"paragraph\">\n<p>reproductive unit of a fungus, capable of developing into a new organism</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_anamorph\">3.8. anamorph</h3>\n<div class=\"paragraph\">\n<p>asexual reproductive state of a fungus</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSome medicinal fungi are primarily known by their anamorph names.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_teleomorph\">3.9. teleomorph</h3>\n<div class=\"paragraph\">\n<p>sexual reproductive state of a fungus</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_holomorph\">3.10. holomorph</h3>\n<div class=\"paragraph\">\n<p>complete fungus including both anamorph and teleomorph states</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_species_complex\">3.11. species complex</h3>\n<div class=\"paragraph\">\n<p>group of closely related species that are difficult to distinguish morphologically</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSpecies complexes are common in medicinal fungi and may have different\nbioactive profiles.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_strain\">3.12. strain</h3>\n<div class=\"paragraph\">\n<p>genetically distinct isolate or subpopulation within a fungal species</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nDifferent strains of the same species may vary in their production of\nbioactive compounds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"taxonomy\">4. Taxonomic classification</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"_general_requirements\">4.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>The taxonomic classification of medicinal fungi shall follow the International\nCode of Nomenclature for algae, fungi, and plants (ICN).</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_taxonomic_hierarchy\">4.2. Taxonomic hierarchy</h3>\n<div class=\"paragraph\">\n<p>Medicinal fungi shall be classified according to the following taxonomic\nhierarchy:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Kingdom</p>\n</li>\n<li>\n<p>Phylum</p>\n</li>\n<li>\n<p>Class</p>\n</li>\n<li>\n<p>Order</p>\n</li>\n<li>\n<p>Family</p>\n</li>\n<li>\n<p>Genus</p>\n</li>\n<li>\n<p>Species</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_scientific_names\">4.3. Scientific names</h3>\n<div class=\"sect3\">\n<h4 id=\"_latin_binomial\">4.3.1. Latin binomial</h4>\n<div class=\"paragraph\">\n<p>The scientific name of a medicinal fungus shall be expressed as a Latin\nbinomial consisting of genus name (capitalized) and species epithet\n(lowercase).</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum, Cordyceps sinensis, Lentinula edodes\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_author_citation\">4.3.2. Author citation</h4>\n<div class=\"paragraph\">\n<p>When first mention of a species is made in a document, the author citation\nshall be included.</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum (Curtis) P. Karst.\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_taxonomic_authorities\">4.3.3. Taxonomic authorities</h4>\n<div class=\"paragraph\">\n<p>Taxonomic nomenclature shall be verified against recognized databases:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Index Fungorum</p>\n</li>\n<li>\n<p>MycoBank</p>\n</li>\n<li>\n<p>GBIF (Global Biodiversity Information Facility)</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_synonyms_and_deprecated_names\">4.4. Synonyms and deprecated names</h3>\n<div class=\"sect3\">\n<h4 id=\"_synonym_handling\">4.4.1. Synonym handling</h4>\n<div class=\"paragraph\">\n<p>When a species has known synonyms, the currently accepted name shall be used\nas the primary identifier. Common synonyms may be listed for reference.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_deprecated_names\">4.4.2. Deprecated names</h4>\n<div class=\"paragraph\">\n<p>Names that have been taxonomically rejected or superseded shall be marked as\ndeprecated and shall not be used as primary identifiers.</p>\n</div>\n<table id=\"table-common-fungi\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Common medicinal fungi: accepted names and synonyms</caption>\n<colgroup>\n<col style=\"width: 40%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 30%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Accepted name</th>\n<th class=\"tableblock halign-left valign-top\">Common synonyms</th>\n<th class=\"tableblock halign-left valign-top\">Common name</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Ganoderma lucidum</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">G. lucidum sensu stricto</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Reishi, Lingzhi</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lentinula edodes</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lentinus edodes</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Shiitake</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Trametes versicolor</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Coriolus versicolor, Polyporus versicolor</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Turkey Tail, Yun Zhi</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cordyceps sinensis</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Ophiocordyceps sinensis</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Caterpillar fungus, Yartsa Gunbu</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Inonotus obliquus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fuscoporia obliqua</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Chaga</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hericium erinaceus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hydnum erinaceus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lion&#8217;s Mane, Yamabushitake</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"nomenclature\">5. Nomenclature standards</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"_general_requirements_2\">5.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>This clause establishes standards for the use of nomenclature in scientific\npublications, product labels, and regulatory documents.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_documentation_requirements\">5.2. Documentation requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_required_elements\">5.2.1. Required elements</h4>\n<div class=\"paragraph\">\n<p>The following elements shall be included in all references to medicinal fungi:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Scientific name (genus and species)\nb) Authority citation (on first mention)\nc) Part of fungus used (fruiting body, mycelium, sclerotium, etc.)\nd) Source (wild-collected or cultivated)</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_recommended_elements\">5.2.2. Recommended elements</h4>\n<div class=\"paragraph\">\n<p>The following elements are recommended for comprehensive documentation:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Strain identifier (if applicable)</p>\n</li>\n<li>\n<p>Geographic origin</p>\n</li>\n<li>\n<p>Cultivation method</p>\n</li>\n<li>\n<p>Harvest date</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_product_labeling\">5.3. Product labeling</h3>\n<div class=\"sect3\">\n<h4 id=\"_standard_format\">5.3.1. Standard format</h4>\n<div class=\"paragraph\">\n<p>Product labels shall include the scientific name of the fungal ingredient.</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum (Reishi) fruiting body extract\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_common_names\">5.3.2. Common names</h4>\n<div class=\"paragraph\">\n<p>Common names may be included alongside scientific names but shall not replace\nthem as the primary identifier.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_control_documentation\">5.4. Quality control documentation</h3>\n<div class=\"sect3\">\n<h4 id=\"_voucher_specimens\">5.4.1. Voucher specimens</h4>\n<div class=\"paragraph\">\n<p>Voucher specimens shall be preserved for all medicinal fungi used in research\nor commercial production.</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSee SIPM-0001 for requirements for voucher specimens.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_identification_records\">5.4.2. Identification records</h4>\n<div class=\"paragraph\">\n<p>Records shall be maintained documenting the taxonomic identification process,\nincluding:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Morphological characteristics observed</p>\n</li>\n<li>\n<p>Reference materials used for comparison</p>\n</li>\n<li>\n<p>Name and qualifications of the identifier</p>\n</li>\n<li>\n<p>Date of identification</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_species_specific_requirements\">5.5. Species-specific requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_ganoderma_species\">5.5.1. Ganoderma species</h4>\n<div class=\"paragraph\">\n<p>Due to taxonomic complexity within the Ganoderma genus, identification shall\ninclude:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Macroscopic characteristics of the fruiting body</p>\n</li>\n<li>\n<p>Microscopic characteristics of spores and hyphae</p>\n</li>\n<li>\n<p>Geographic origin information</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_cordyceps_species\">5.5.2. Cordyceps species</h4>\n<div class=\"paragraph\">\n<p>Cordyceps products shall specify:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Species identity (C. sinensis, C. militaris, or other)</p>\n</li>\n<li>\n<p>Whether the product contains the natural complex (fungus + host) or\ncultured mycelium</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nC. sinensis is endangered in the wild; cultured alternatives are\ncommonly used.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[<a id=\"Kirk\"></a>, <em>Dictionary of the Fungi</em>. 10th ed. CABI Publishing,\nWallingford, UK, 2008</p>\n</li>\n<li>\n<p>[<a id=\"Stamets\"></a>, <em>Growing Gourmet and Medicinal Mushrooms</em>.\n3rd ed. Ten Speed Press, Berkeley, CA, 2000</p>\n</li>\n<li>\n<p>[<a id=\"Wasser\"></a>, Medicinal mushrooms as a source of antitumor and\nimmunomodulating polysaccharides. <em>Appl. Microbiol. Biotechnol.</em> 2002,\n<strong>60</strong> pp. 258-274</p>\n</li>\n<li>\n<p>[<a id=\"Hobbs\"></a>, <em>Medicinal Mushrooms: An Exploration of Tradition,\nHealing, and Culture</em>. Botanica Press, Santa Cruz, CA, 1995</p>\n</li>\n<li>\n<p>[<a id=\"Chang\"></a>, <em>Mushroom Biology and Mushroom Products</em>.\nChinese University Press, Hong Kong, 1993</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_medicinal_fungus",
+          "title": "medicinal fungus",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_basidiomycete",
+          "title": "basidiomycete",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_ascomycete",
+          "title": "ascomycete",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_fruiting_body",
+          "title": "fruiting body",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_mycelium",
+          "title": "mycelium",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_sclerotium",
+          "title": "sclerotium",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_spore",
+          "title": "spore",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_anamorph",
+          "title": "anamorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_teleomorph",
+          "title": "teleomorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_holomorph",
+          "title": "holomorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_species_complex",
+          "title": "species complex",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_strain",
+          "title": "strain",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "taxonomy",
+      "title": "Taxonomic classification",
+      "level": 1,
+      "children": [
+        {
+          "id": "_general_requirements",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_taxonomic_hierarchy",
+          "title": "Taxonomic hierarchy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_scientific_names",
+          "title": "Scientific names",
+          "level": 2,
+          "children": [
+            {
+              "id": "_latin_binomial",
+              "title": "Latin binomial",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_author_citation",
+              "title": "Author citation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_taxonomic_authorities",
+              "title": "Taxonomic authorities",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_synonyms_and_deprecated_names",
+          "title": "Synonyms and deprecated names",
+          "level": 2,
+          "children": [
+            {
+              "id": "_synonym_handling",
+              "title": "Synonym handling",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_deprecated_names",
+              "title": "Deprecated names",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nomenclature",
+      "title": "Nomenclature standards",
+      "level": 1,
+      "children": [
+        {
+          "id": "_general_requirements_2",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_documentation_requirements",
+          "title": "Documentation requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_required_elements",
+              "title": "Required elements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_recommended_elements",
+              "title": "Recommended elements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_product_labeling",
+          "title": "Product labeling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_standard_format",
+              "title": "Standard format",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_common_names",
+              "title": "Common names",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_quality_control_documentation",
+          "title": "Quality control documentation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_voucher_specimens",
+              "title": "Voucher specimens",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_identification_records",
+              "title": "Identification records",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_species_specific_requirements",
+          "title": "Species-specific requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_ganoderma_species",
+              "title": "Ganoderma species",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_cordyceps_species",
+              "title": "Cordyceps species",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Medicinal Fungi Taxonomy\n:docnumber: 0002\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Medicinal Fungi Taxonomy and Nomenclature\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 2\n:technical-committee: Fungi and Lichens\n:library-ics: 07.100.20;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-taxonomy.adoc[]\n\ninclude::sections/05-nomenclature.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/public/content/standards/SIPM-0200.json
+++ b/public/content/standards/SIPM-0200.json
@@ -1,0 +1,377 @@
+{
+  "id": "SIPM-0200",
+  "title": "Agricultural Practices for Medicinal Plants",
+  "attributes": {
+    "docnumber": "0200",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Agricultural Practices for Medicinal Plants",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Agricultural Practices",
+    "library-ics": "65.020.20;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_cultivation_site\">3.1. cultivation site</a></li>\n<li><a href=\"#_seed_stock\">3.2. seed stock</a></li>\n<li><a href=\"#_cultivation_protocol\">3.3. cultivation protocol</a></li>\n<li><a href=\"#_plant_protection\">3.4. plant protection</a></li>\n<li><a href=\"#_primary_processing\">3.5. primary processing</a></li>\n<li><a href=\"#_batch\">3.6. batch</a></li>\n<li><a href=\"#_traceability\">3.7. traceability</a></li>\n</ul>\n</li>\n<li><a href=\"#site-selection\">4. Site selection and preparation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-site-criteria\">4.1. Site selection criteria</a></li>\n<li><a href=\"#sec-site-records\">4.2. Site documentation</a></li>\n<li><a href=\"#_soil_management\">4.3. Soil management</a></li>\n</ul>\n</li>\n<li><a href=\"#propagation\">5. Propagation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-seed-stock\">5.1. Seed stock requirements</a></li>\n<li><a href=\"#sec-propagation-methods\">5.2. Propagation methods</a></li>\n<li><a href=\"#sec-nursery\">5.3. Nursery management</a></li>\n</ul>\n</li>\n<li><a href=\"#cultivation\">6. Cultivation management</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-planting\">6.1. Planting and establishment</a></li>\n<li><a href=\"#sec-irrigation\">6.2. Irrigation</a></li>\n<li><a href=\"#sec-plant-protection\">6.3. Plant protection</a></li>\n<li><a href=\"#sec-records\">6.4. Cultivation records</a></li>\n</ul>\n</li>\n<li><a href=\"#harvesting\">7. Harvesting</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-harvest-timing\">7.1. Harvest timing</a></li>\n<li><a href=\"#sec-harvest-methods\">7.2. Harvest methods</a></li>\n<li><a href=\"#sec-field-handling\">7.3. Field handling</a></li>\n</ul>\n</li>\n<li><a href=\"#postharvest\">8. Post-harvest processing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-primary-processing\">8.1. Primary processing operations</a></li>\n<li><a href=\"#sec-packaging\">8.2. Packaging and labeling</a></li>\n<li><a href=\"#sec-storage\">8.3. Storage</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 3,\n<em>Agricultural Practices</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0200.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0200 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The quality of phytomedicine products begins with the quality of the raw plant\nmaterial. Agricultural practices directly influence the identity, purity,\npotency, and safety of medicinal plants and, consequently, the final products\nderived from them. This standard establishes requirements for the cultivation,\ncollection, and primary processing of medicinal plants to ensure consistent\nquality throughout the supply chain.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document is aligned with international guidelines, including the WHO\nGuidelines on Good Agricultural and Collection Practices (GACP) for Medicinal\nPlants, and incorporates additional requirements specific to the phytomedicine\nindustry.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses the complete agricultural production cycle:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Site selection and preparation</p>\n</li>\n<li>\n<p>Propagation and cultivation</p>\n</li>\n<li>\n<p>Plant protection and pest management</p>\n</li>\n<li>\n<p>Harvesting and primary processing</p>\n</li>\n<li>\n<p>Storage and transportation</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Implementation of this standard supports:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Traceability of medicinal plant materials</p>\n</li>\n<li>\n<p>Consistency of phytochemical profiles</p>\n</li>\n<li>\n<p>Minimization of contamination risks</p>\n</li>\n<li>\n<p>Environmental sustainability</p>\n</li>\n<li>\n<p>Social responsibility in medicinal plant production</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the agricultural cultivation and\nprimary processing of medicinal plants used in phytomedicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Cultivation of medicinal plants under controlled agricultural conditions</p>\n</li>\n<li>\n<p>Primary processing of plant materials after harvest</p>\n</li>\n<li>\n<p>Documentation and traceability throughout the production cycle</p>\n</li>\n<li>\n<p>Quality management systems for medicinal plant production</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Wild collection practices (addressed in SIPM-0201)</p>\n</li>\n<li>\n<p>Processing of plant materials into extracts or finished products</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Fungal cultivation (addressed in SIPM-0202)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The requirements in this document are intended to be used by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Cultivators and farmers of medicinal plants</p>\n</li>\n<li>\n<p>Primary processors of medicinal plant materials</p>\n</li>\n<li>\n<p>Quality assurance personnel</p>\n</li>\n<li>\n<p>Regulatory bodies and certification organizations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"WHOGACP\"></a>[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</p>\n</li>\n<li>\n<p><a id=\"ISO9001\"></a>[ISO 9001:2015], Quality management systems&#8201;&#8212;&#8201;Requirements</p>\n</li>\n<li>\n<p><a id=\"ISO14001\"></a>[ISO 14001:2015], Environmental management systems&#8201;&#8212;&#8201;Requirements\nwith guidance for use</p>\n</li>\n<li>\n<p><a id=\"GLOBALGAP\"></a>[GLOBALG.A.P. Integrated Farm Assurance Standard]</p>\n</li>\n<li>\n<p><a id=\"EUROPAM\"></a>[European Herb Growers Association (EUROPAM) Good Agricultural Practice Guidelines]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_cultivation_site\">3.1. cultivation site</h3>\n<div class=\"paragraph\">\n<p>area of land or controlled environment used for growing medicinal plants</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCultivation sites may include open fields, greenhouses, hydroponic\nsystems, or other controlled environments.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_seed_stock\">3.2. seed stock</h3>\n<div class=\"paragraph\">\n<p>material used for propagation, including true seeds, cuttings, rhizomes,\nbulbs, or other vegetative propagation material</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_cultivation_protocol\">3.3. cultivation protocol</h3>\n<div class=\"paragraph\">\n<p>documented procedures for growing a specific medicinal plant species,\nincluding environmental parameters, inputs, and timing</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_plant_protection\">3.4. plant protection</h3>\n<div class=\"paragraph\">\n<p>measures taken to protect medicinal plants from pests, diseases, and other\nthreats to their health and quality</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_primary_processing\">3.5. primary processing</h3>\n<div class=\"paragraph\">\n<p>initial processing of plant material after harvest, including cleaning,\ndrying, cutting, and packaging</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nPrimary processing does not include extraction or formulation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_batch\">3.6. batch</h3>\n<div class=\"paragraph\">\n<p>defined quantity of plant material produced in a single process or series of\nprocesses, allowing for traceability</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traceability\">3.7. traceability</h3>\n<div class=\"paragraph\">\n<p>ability to trace the history, application, or location of plant material\nthrough recorded identification data</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"site-selection\">4. Site selection and preparation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-site-criteria\">4.1. Site selection criteria</h3>\n<div class=\"sect3\">\n<h4 id=\"_environmental_requirements\">4.1.1. Environmental requirements</h4>\n<div class=\"paragraph\">\n<p>The cultivation site shall meet the environmental requirements of the target\nplant species, including:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Climate conditions (temperature, rainfall, sunlight)\nb) Soil characteristics (type, pH, drainage, nutrient content)\nc) Water availability and quality\nd) Altitude and topography</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_contamination_assessment\">4.1.2. Contamination assessment</h4>\n<div class=\"paragraph\">\n<p>Prior to establishment, the site shall be assessed for potential sources of\ncontamination, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Previous land use and potential residual contaminants</p>\n</li>\n<li>\n<p>Proximity to industrial facilities or major transportation routes</p>\n</li>\n<li>\n<p>Presence of heavy metals in soil and water</p>\n</li>\n<li>\n<p>Risk of pesticide drift from neighboring agricultural operations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-site-records\">4.2. Site documentation</h3>\n<div class=\"paragraph\">\n<p>The following documentation shall be maintained:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Site location and boundaries (geographic coordinates)</p>\n</li>\n<li>\n<p>History of land use for at least the previous 5 years</p>\n</li>\n<li>\n<p>Results of soil and water testing</p>\n</li>\n<li>\n<p>Map of the cultivation area</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_soil_management\">4.3. Soil management</h3>\n<div class=\"sect3\">\n<h4 id=\"_soil_testing\">4.3.1. Soil testing</h4>\n<div class=\"paragraph\">\n<p>Soil shall be tested prior to planting and periodically during cultivation for:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Nutrient content</p>\n</li>\n<li>\n<p>pH level</p>\n</li>\n<li>\n<p>Heavy metal content</p>\n</li>\n<li>\n<p>Organic matter content</p>\n</li>\n<li>\n<p>Presence of pathogens</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_soil_amendment\">4.3.2. Soil amendment</h4>\n<div class=\"paragraph\">\n<p>Soil amendments, including fertilizers and conditioners, shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Documented with product name, source, and application rate</p>\n</li>\n<li>\n<p>Applied according to label instructions or professional recommendations</p>\n</li>\n<li>\n<p>Sourced from suppliers who provide certificates of analysis</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"propagation\">5. Propagation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-seed-stock\">5.1. Seed stock requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_verification\">5.1.1. Identity verification</h4>\n<div class=\"paragraph\">\n<p>The identity of seed stock shall be verified to species level before\npropagation. Acceptable methods include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Purchase from certified suppliers with documentation</p>\n</li>\n<li>\n<p>Comparison with reference materials</p>\n</li>\n<li>\n<p>DNA-based authentication (where applicable)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_quality_requirements\">5.1.2. Quality requirements</h4>\n<div class=\"paragraph\">\n<p>Seed stock shall be free from:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Visible signs of disease or pest damage</p>\n</li>\n<li>\n<p>Contamination with seeds of other species</p>\n</li>\n<li>\n<p>Physical damage or deterioration</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-propagation-methods\">5.2. Propagation methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_documentation\">5.2.1. Documentation</h4>\n<div class=\"paragraph\">\n<p>The propagation method used shall be documented, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Type of propagation material (seed, cutting, rhizome, etc.)</p>\n</li>\n<li>\n<p>Source of propagation material</p>\n</li>\n<li>\n<p>Date of propagation</p>\n</li>\n<li>\n<p>Environmental conditions</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_vegetative_propagation\">5.2.2. Vegetative propagation</h4>\n<div class=\"paragraph\">\n<p>For vegetatively propagated species:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Mother plants shall be positively identified and healthy</p>\n</li>\n<li>\n<p>Regular inspection for trueness-to-type shall be conducted</p>\n</li>\n<li>\n<p>Records of mother plant lineage shall be maintained</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-nursery\">5.3. Nursery management</h3>\n<div class=\"paragraph\">\n<p>Nursery operations shall be conducted in a manner that:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Prevents cross-contamination between species or batches</p>\n</li>\n<li>\n<p>Maintains appropriate environmental conditions</p>\n</li>\n<li>\n<p>Includes regular inspection for pests and diseases</p>\n</li>\n<li>\n<p>Documents all inputs and treatments applied</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"cultivation\">6. Cultivation management</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-planting\">6.1. Planting and establishment</h3>\n<div class=\"paragraph\">\n<p>Planting operations shall be documented, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Date of planting</p>\n</li>\n<li>\n<p>Plant spacing and density</p>\n</li>\n<li>\n<p>Number of plants or quantity of seed used</p>\n</li>\n<li>\n<p>Field or bed identification</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-irrigation\">6.2. Irrigation</h3>\n<div class=\"sect3\">\n<h4 id=\"_water_quality\">6.2.1. Water quality</h4>\n<div class=\"paragraph\">\n<p>Irrigation water shall meet quality standards appropriate for the intended\nuse, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Absence of pathogenic microorganisms</p>\n</li>\n<li>\n<p>Acceptable levels of chemical contaminants</p>\n</li>\n<li>\n<p>pH within appropriate range</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_irrigation_records\">6.2.2. Irrigation records</h4>\n<div class=\"paragraph\">\n<p>Irrigation records shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Source of water</p>\n</li>\n<li>\n<p>Method of application</p>\n</li>\n<li>\n<p>Frequency and duration</p>\n</li>\n<li>\n<p>Any treatments applied to water</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-plant-protection\">6.3. Plant protection</h3>\n<div class=\"sect3\">\n<h4 id=\"_integrated_pest_management\">6.3.1. Integrated pest management</h4>\n<div class=\"paragraph\">\n<p>Plant protection shall be based on integrated pest management (IPM) principles:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Prevention through good cultural practices</p>\n</li>\n<li>\n<p>Monitoring and early detection</p>\n</li>\n<li>\n<p>Use of biological controls where appropriate</p>\n</li>\n<li>\n<p>Chemical controls only when necessary and permitted</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_pesticide_use\">6.3.2. Pesticide use</h4>\n<div class=\"paragraph\">\n<p>When pesticides are used:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Only products approved for use on medicinal plants shall be applied</p>\n</li>\n<li>\n<p>Application shall follow label instructions</p>\n</li>\n<li>\n<p>Pre-harvest intervals shall be strictly observed</p>\n</li>\n<li>\n<p>All applications shall be documented</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMany jurisdictions have specific restrictions on pesticide use for\nmedicinal plants.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-records\">6.4. Cultivation records</h3>\n<div class=\"paragraph\">\n<p>Records shall be maintained throughout the cultivation period, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Planting dates and methods</p>\n</li>\n<li>\n<p>Environmental conditions (where controlled)</p>\n</li>\n<li>\n<p>Irrigation and fertilization</p>\n</li>\n<li>\n<p>Pest and disease observations and treatments</p>\n</li>\n<li>\n<p>Any deviation from standard protocols</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"harvesting\">7. Harvesting</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-harvest-timing\">7.1. Harvest timing</h3>\n<div class=\"sect3\">\n<h4 id=\"_optimal_harvest_time\">7.1.1. Optimal harvest time</h4>\n<div class=\"paragraph\">\n<p>Harvest timing shall be determined based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Phytochemical content of the target plant part</p>\n</li>\n<li>\n<p>Stage of plant development</p>\n</li>\n<li>\n<p>Time of day (for species where this affects quality)</p>\n</li>\n<li>\n<p>Environmental conditions</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_documentation_2\">7.1.2. Documentation</h4>\n<div class=\"paragraph\">\n<p>The rationale for harvest timing decisions shall be documented.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-harvest-methods\">7.2. Harvest methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_personnel_requirements\">7.2.1. Personnel requirements</h4>\n<div class=\"paragraph\">\n<p>Harvest personnel shall be trained in:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Correct plant part identification</p>\n</li>\n<li>\n<p>Harvesting techniques</p>\n</li>\n<li>\n<p>Hygiene requirements</p>\n</li>\n<li>\n<p>Recognition of contamination or quality issues</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_equipment\">7.2.2. Equipment</h4>\n<div class=\"paragraph\">\n<p>Harvest equipment shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clean and in good working condition</p>\n</li>\n<li>\n<p>Constructed of materials that do not contaminate plant material</p>\n</li>\n<li>\n<p>Regularly inspected and maintained</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-field-handling\">7.3. Field handling</h3>\n<div class=\"sect3\">\n<h4 id=\"_contamination_prevention\">7.3.1. Contamination prevention</h4>\n<div class=\"paragraph\">\n<p>Harvested material shall be protected from contamination during handling:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clean containers shall be used</p>\n</li>\n<li>\n<p>Contact with soil shall be minimized</p>\n</li>\n<li>\n<p>Material shall not be placed directly on the ground</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_temperature_management\">7.3.2. Temperature management</h4>\n<div class=\"paragraph\">\n<p>For temperature-sensitive materials:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Exposure to direct sunlight shall be minimized</p>\n</li>\n<li>\n<p>Material shall be transported to processing area promptly</p>\n</li>\n<li>\n<p>Temporary storage conditions shall be documented</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"postharvest\">8. Post-harvest processing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-primary-processing\">8.1. Primary processing operations</h3>\n<div class=\"sect3\">\n<h4 id=\"_cleaning\">8.1.1. Cleaning</h4>\n<div class=\"paragraph\">\n<p>Harvested material shall be cleaned to remove:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Soil and extraneous matter</p>\n</li>\n<li>\n<p>Damaged or diseased plant parts</p>\n</li>\n<li>\n<p>Non-target plant species</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_drying\">8.1.2. Drying</h4>\n<div class=\"paragraph\">\n<p>Drying operations shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Use appropriate temperature for the species</p>\n</li>\n<li>\n<p>Ensure adequate air circulation</p>\n</li>\n<li>\n<p>Achieve target moisture content for storage stability</p>\n</li>\n<li>\n<p>Be documented with temperature and duration records</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_cutting_and_size_reduction\">8.1.3. Cutting and size reduction</h4>\n<div class=\"paragraph\">\n<p>When cutting or size reduction is performed:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Equipment shall be clean and appropriate for the material</p>\n</li>\n<li>\n<p>Dust generation shall be controlled</p>\n</li>\n<li>\n<p>Material identity shall be maintained throughout</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-packaging\">8.2. Packaging and labeling</h3>\n<div class=\"sect3\">\n<h4 id=\"_container_requirements\">8.2.1. Container requirements</h4>\n<div class=\"paragraph\">\n<p>Primary packaging shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Protect material from contamination</p>\n</li>\n<li>\n<p>Preserve material quality during storage</p>\n</li>\n<li>\n<p>Be appropriate for the material characteristics</p>\n</li>\n<li>\n<p>Be traceable to batch and source</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_labeling_requirements\">8.2.2. Labeling requirements</h4>\n<div class=\"paragraph\">\n<p>Each container shall be labeled with at minimum:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Plant name (scientific name and common name)</p>\n</li>\n<li>\n<p>Plant part</p>\n</li>\n<li>\n<p>Batch number</p>\n</li>\n<li>\n<p>Date of processing</p>\n</li>\n<li>\n<p>Net weight</p>\n</li>\n<li>\n<p>Storage conditions</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-storage\">8.3. Storage</h3>\n<div class=\"paragraph\">\n<p>Storage conditions shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Appropriate for maintaining material quality</p>\n</li>\n<li>\n<p>Protected from pests and contamination</p>\n</li>\n<li>\n<p>Controlled for temperature and humidity where required</p>\n</li>\n<li>\n<p>Documented with monitoring records</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"FAOGAP\"></a>[FAO Good Agricultural Practices], Food and Agriculture Organization\nof the United Nations, Rome</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials], World\nHealth Organization, Geneva, 1998</p>\n</li>\n<li>\n<p><a id=\"AHPAGAP\"></a>[AHPA Good Agricultural Practices], American Herbal Products\nAssociation, Silver Spring, MD</p>\n</li>\n<li>\n<p>[<a id=\"Craker\"></a>, <em>Herbs, Botanicals and Teas</em>. Haworth Press,\nBinghamton, NY, 2000</p>\n</li>\n<li>\n<p>[<a id=\"Simon\"></a>, <em>Herbs: An Indexed Bibliography, 1971-1980</em>.\nElsevier, Amsterdam, 1984</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_cultivation_site",
+          "title": "cultivation site",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_seed_stock",
+          "title": "seed stock",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_cultivation_protocol",
+          "title": "cultivation protocol",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_plant_protection",
+          "title": "plant protection",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_primary_processing",
+          "title": "primary processing",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_batch",
+          "title": "batch",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traceability",
+          "title": "traceability",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "site-selection",
+      "title": "Site selection and preparation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-site-criteria",
+          "title": "Site selection criteria",
+          "level": 2,
+          "children": [
+            {
+              "id": "_environmental_requirements",
+              "title": "Environmental requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_contamination_assessment",
+              "title": "Contamination assessment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-site-records",
+          "title": "Site documentation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_soil_management",
+          "title": "Soil management",
+          "level": 2,
+          "children": [
+            {
+              "id": "_soil_testing",
+              "title": "Soil testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_soil_amendment",
+              "title": "Soil amendment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "propagation",
+      "title": "Propagation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-seed-stock",
+          "title": "Seed stock requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_verification",
+              "title": "Identity verification",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_quality_requirements",
+              "title": "Quality requirements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-propagation-methods",
+          "title": "Propagation methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_documentation",
+              "title": "Documentation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_vegetative_propagation",
+              "title": "Vegetative propagation",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-nursery",
+          "title": "Nursery management",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "cultivation",
+      "title": "Cultivation management",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-planting",
+          "title": "Planting and establishment",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-irrigation",
+          "title": "Irrigation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_water_quality",
+              "title": "Water quality",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_irrigation_records",
+              "title": "Irrigation records",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-plant-protection",
+          "title": "Plant protection",
+          "level": 2,
+          "children": [
+            {
+              "id": "_integrated_pest_management",
+              "title": "Integrated pest management",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_pesticide_use",
+              "title": "Pesticide use",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-records",
+          "title": "Cultivation records",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "harvesting",
+      "title": "Harvesting",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-harvest-timing",
+          "title": "Harvest timing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_optimal_harvest_time",
+              "title": "Optimal harvest time",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_documentation_2",
+              "title": "Documentation",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-harvest-methods",
+          "title": "Harvest methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_personnel_requirements",
+              "title": "Personnel requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_equipment",
+              "title": "Equipment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-field-handling",
+          "title": "Field handling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_contamination_prevention",
+              "title": "Contamination prevention",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_temperature_management",
+              "title": "Temperature management",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "postharvest",
+      "title": "Post-harvest processing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-primary-processing",
+          "title": "Primary processing operations",
+          "level": 2,
+          "children": [
+            {
+              "id": "_cleaning",
+              "title": "Cleaning",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_drying",
+              "title": "Drying",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_cutting_and_size_reduction",
+              "title": "Cutting and size reduction",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-packaging",
+          "title": "Packaging and labeling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_container_requirements",
+              "title": "Container requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_labeling_requirements",
+              "title": "Labeling requirements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-storage",
+          "title": "Storage",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Agricultural Practices for Medicinal Plants\n:docnumber: 0200\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Agricultural Practices for Medicinal Plants\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 3\n:technical-committee: Agricultural Practices\n:library-ics: 65.020.20;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-site-selection.adoc[]\n\ninclude::sections/05-propagation.adoc[]\n\ninclude::sections/06-cultivation.adoc[]\n\ninclude::sections/07-harvesting.adoc[]\n\ninclude::sections/08-postharvest.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/public/content/standards/SIPM-0300.json
+++ b/public/content/standards/SIPM-0300.json
@@ -1,0 +1,376 @@
+{
+  "id": "SIPM-0300",
+  "title": "Analytical Methods for Phytomedicine",
+  "attributes": {
+    "docnumber": "0300",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Analytical Methods for Phytomedicine",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Analytical Methods",
+    "library-ics": "07.100.01;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_analytical_procedure\">3.1. analytical procedure</a></li>\n<li><a href=\"#_method_validation\">3.2. method validation</a></li>\n<li><a href=\"#_specificity\">3.3. specificity</a></li>\n<li><a href=\"#_accuracy\">3.4. accuracy</a></li>\n<li><a href=\"#_precision\">3.5. precision</a></li>\n<li><a href=\"#_repeatability\">3.6. repeatability</a></li>\n<li><a href=\"#_intermediate_precision\">3.7. intermediate precision</a></li>\n<li><a href=\"#_reproducibility\">3.8. reproducibility</a></li>\n<li><a href=\"#_limit_of_detection\">3.9. limit of detection</a></li>\n<li><a href=\"#_limit_of_quantitation\">3.10. limit of quantitation</a></li>\n<li><a href=\"#_linearity\">3.11. linearity</a></li>\n<li><a href=\"#_range\">3.12. range</a></li>\n<li><a href=\"#_robustness\">3.13. robustness</a></li>\n<li><a href=\"#_reference_standard\">3.14. reference standard</a></li>\n<li><a href=\"#_system_suitability\">3.15. system suitability</a></li>\n</ul>\n</li>\n<li><a href=\"#identity\">4. Identity testing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-identity-general\">4.1. General requirements</a></li>\n<li><a href=\"#_methods_of_identity_testing\">4.2. Methods of identity testing</a></li>\n<li><a href=\"#sec-identity-acceptance\">4.3. Acceptance criteria</a></li>\n</ul>\n</li>\n<li><a href=\"#purity\">5. Purity testing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-purity-general\">5.1. General requirements</a></li>\n<li><a href=\"#sec-contaminants\">5.2. Contaminant categories</a></li>\n</ul>\n</li>\n<li><a href=\"#potency\">6. Potency determination</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-potency-general\">6.1. General requirements</a></li>\n<li><a href=\"#sec-analyte-selection\">6.2. Analyte selection</a></li>\n<li><a href=\"#sec-methods\">6.3. Quantitative methods</a></li>\n<li><a href=\"#sec-specifications\">6.4. Specifications</a></li>\n</ul>\n</li>\n<li><a href=\"#validation\">7. Method validation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-validation-requirements\">7.1. Validation requirements</a></li>\n<li><a href=\"#sec-validation-parameters\">7.2. Validation parameters</a></li>\n<li><a href=\"#sec-protocol\">7.3. Validation protocol</a></li>\n<li><a href=\"#sec-report\">7.4. Validation report</a></li>\n<li><a href=\"#sec-revalidation\">7.5. Revalidation</a></li>\n</ul>\n</li>\n<li><a href=\"#reporting\">8. Reporting of results</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-report-content\">8.1. Certificate of analysis</a></li>\n<li><a href=\"#sec-result-expression\">8.2. Expression of results</a></li>\n<li><a href=\"#sec-records\">8.3. Record retention</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 4,\n<em>Analytical Methods</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0300.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0300 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The quality and safety of phytomedicine products depend on reliable analytical\nmethods for identity verification, purity assessment, and potency determination.\nUnlike conventional pharmaceuticals, phytomedicines present unique analytical\nchallenges due to their complex chemical composition and natural variability.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes general requirements for analytical methods used in\nthe quality control of phytomedicine products. It provides a framework for\nmethod selection, validation, and application that ensures reliable and\nreproducible results across laboratories and jurisdictions.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses three fundamental aspects of phytomedicine analysis:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p><strong>Identity</strong>: Confirming that the material is what it purports to be</p>\n</li>\n<li>\n<p><strong>Purity</strong>: Ensuring the material is free from unacceptable contamination</p>\n</li>\n<li>\n<p><strong>Potency</strong>: Determining the concentration of active or marker constituents</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to be used in conjunction with specific analytical\nmethod standards in the SIPM-0300 series, which provide detailed procedures\nfor particular tests and analytes.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies general requirements for analytical methods used in\nthe quality control of phytomedicine products.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Identity testing of plant materials and extracts</p>\n</li>\n<li>\n<p>Purity testing for contaminants and impurities</p>\n</li>\n<li>\n<p>Potency determination for active or marker constituents</p>\n</li>\n<li>\n<p>Method validation and verification</p>\n</li>\n<li>\n<p>Documentation and reporting of analytical results</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Herbal substances and preparations</p>\n</li>\n<li>\n<p>Medicinal fungi materials and products</p>\n</li>\n<li>\n<p>Finished phytomedicine products</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Specific analytical procedures for individual compounds or matrices</p>\n</li>\n<li>\n<p>Microbiological testing methods</p>\n</li>\n<li>\n<p>Clinical laboratory methods</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICHQ2R2\"></a>[ICH Q2(R2) Validation of Analytical Procedures]</p>\n</li>\n<li>\n<p><a id=\"ISO17025\"></a>[ISO/IEC 17025:2017], General requirements for the competence of\ntesting and calibration laboratories</p>\n</li>\n<li>\n<p><a id=\"ISO5725-1\"></a>[ISO 5725-1:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 1: General principles and definitions</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials]</p>\n</li>\n<li>\n<p><a id=\"ICHQ3R8\"></a>[ICH Q3(R8) Guideline for Elemental Impurities]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_analytical_procedure\">3.1. analytical procedure</h3>\n<div class=\"paragraph\">\n<p>detailed description of the steps required to perform an analytical test</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nAnalytical procedures include sample preparation, measurement, and\ncalculation steps.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_method_validation\">3.2. method validation</h3>\n<div class=\"paragraph\">\n<p>process of demonstrating that an analytical procedure is suitable for its\nintended purpose</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_specificity\">3.3. specificity</h3>\n<div class=\"paragraph\">\n<p>alt:[selectivity]</p>\n</div>\n<div class=\"paragraph\">\n<p>ability of an analytical procedure to assess unequivocally the analyte in the\npresence of components that may be expected to be present</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_accuracy\">3.4. accuracy</h3>\n<div class=\"paragraph\">\n<p>alt:[trueness]</p>\n</div>\n<div class=\"paragraph\">\n<p>closeness of agreement between the value found and the value accepted as true</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_precision\">3.5. precision</h3>\n<div class=\"paragraph\">\n<p>closeness of agreement between a series of measurements obtained from multiple\nsampling of the same homogeneous sample under prescribed conditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_repeatability\">3.6. repeatability</h3>\n<div class=\"paragraph\">\n<p>precision under the same operating conditions over a short interval of time</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_intermediate_precision\">3.7. intermediate precision</h3>\n<div class=\"paragraph\">\n<p>precision within-laboratory variations, such as different days, different\nanalysts, different equipment</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_reproducibility\">3.8. reproducibility</h3>\n<div class=\"paragraph\">\n<p>precision between laboratories</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_limit_of_detection\">3.9. limit of detection</h3>\n<div class=\"paragraph\">\n<p>alt:[LOD]</p>\n</div>\n<div class=\"paragraph\">\n<p>lowest amount of analyte that can be detected but not necessarily quantified</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_limit_of_quantitation\">3.10. limit of quantitation</h3>\n<div class=\"paragraph\">\n<p>alt:[LOQ]</p>\n</div>\n<div class=\"paragraph\">\n<p>lowest amount of analyte that can be quantitatively determined with suitable\nprecision and accuracy</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_linearity\">3.11. linearity</h3>\n<div class=\"paragraph\">\n<p>ability of an analytical procedure to obtain test results that are directly\nproportional to the concentration of analyte within a given range</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_range\">3.12. range</h3>\n<div class=\"paragraph\">\n<p>interval between upper and lower concentration amounts of analyte for which\nthe analytical procedure has suitable precision, accuracy, and linearity</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_robustness\">3.13. robustness</h3>\n<div class=\"paragraph\">\n<p>capacity of an analytical procedure to remain unaffected by small, but\ndeliberate variations in method parameters</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_reference_standard\">3.14. reference standard</h3>\n<div class=\"paragraph\">\n<p>substance or material characterized for use as a measurement standard in\nanalytical procedures</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nReference standards may be primary standards or working standards.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_system_suitability\">3.15. system suitability</h3>\n<div class=\"paragraph\">\n<p>evaluation of the components of an analytical system to ensure that the system\nis operating within acceptable parameters before analysis</p>\n</div>\n<table id=\"table-validation-params\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Method validation parameters by test type</caption>\n<colgroup>\n<col style=\"width: 30%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 40%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Parameter</th>\n<th class=\"tableblock halign-left valign-top\">Identity tests</th>\n<th class=\"tableblock halign-left valign-top\">Quantitative tests</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Specificity</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Accuracy</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Precision (repeatability)</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Intermediate precision</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Linearity</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Range</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">LOD</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">When relevant</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">LOQ</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Robustness</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Recommended</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"identity\">4. Identity testing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-identity-general\">4.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Identity testing shall be performed to confirm that plant material or\npreparations are authentic and correctly identified.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_methods_of_identity_testing\">4.2. Methods of identity testing</h3>\n<div class=\"sect3\">\n<h4 id=\"_macroscopic_examination\">4.2.1. Macroscopic examination</h4>\n<div class=\"paragraph\">\n<p>Macroscopic examination shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Visual assessment of color, form, and texture</p>\n</li>\n<li>\n<p>Odor assessment (where appropriate)</p>\n</li>\n<li>\n<p>Comparison with authenticated reference material or written description</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_microscopic_examination\">4.2.2. Microscopic examination</h4>\n<div class=\"paragraph\">\n<p>Microscopic examination shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Observation of characteristic cellular structures</p>\n</li>\n<li>\n<p>Comparison with reference material or photomicrographs</p>\n</li>\n<li>\n<p>Documentation of distinguishing features</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMicroscopic examination is particularly important for powdered materials.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_chromatographic_methods\">4.2.3. Chromatographic methods</h4>\n<div class=\"paragraph\">\n<p>Chromatographic methods for identity testing shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Produce a fingerprint characteristic of the species</p>\n</li>\n<li>\n<p>Include comparison with authenticated reference material</p>\n</li>\n<li>\n<p>Document retention times and peak patterns</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptable chromatographic methods include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Thin-layer chromatography (TLC)</p>\n</li>\n<li>\n<p>High-performance liquid chromatography (HPLC)</p>\n</li>\n<li>\n<p>Gas chromatography (GC)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_spectroscopic_methods\">4.2.4. Spectroscopic methods</h4>\n<div class=\"paragraph\">\n<p>Spectroscopic methods may be used for identity testing, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Near-infrared spectroscopy (NIR)</p>\n</li>\n<li>\n<p>Fourier-transform infrared spectroscopy (FTIR)</p>\n</li>\n<li>\n<p>Nuclear magnetic resonance (NMR)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_dna_based_methods\">4.2.5. DNA-based methods</h4>\n<div class=\"paragraph\">\n<p>DNA-based authentication shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Use validated marker regions appropriate for the species</p>\n</li>\n<li>\n<p>Include appropriate positive and negative controls</p>\n</li>\n<li>\n<p>Be performed by competent laboratories</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-identity-acceptance\">4.3. Acceptance criteria</h3>\n<div class=\"paragraph\">\n<p>Material shall be considered positively identified when:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Results of identity testing are consistent with reference material or\n   documented characteristics\nb) No evidence of adulteration or substitution is detected\nc) Testing is performed by qualified personnel using validated methods</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"purity\">5. Purity testing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-purity-general\">5.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Purity testing shall be performed to ensure that plant materials and\npreparations are free from unacceptable levels of contaminants.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-contaminants\">5.2. Contaminant categories</h3>\n<div class=\"sect3\">\n<h4 id=\"_foreign_matter\">5.2.1. Foreign matter</h4>\n<div class=\"paragraph\">\n<p>Testing for foreign matter shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Other plant species</p>\n</li>\n<li>\n<p>Plant parts other than the intended part</p>\n</li>\n<li>\n<p>Inert materials (soil, stones, etc.)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance criteria shall be specified based on pharmacopoeial standards or\nproduct specifications.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_heavy_metals\">5.2.2. Heavy metals</h4>\n<div class=\"paragraph\">\n<p>Heavy metal testing shall include, at minimum:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Lead (Pb)</p>\n</li>\n<li>\n<p>Cadmium (Cd)</p>\n</li>\n<li>\n<p>Mercury (Hg)</p>\n</li>\n<li>\n<p>Arsenic (As)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance limits shall be established based on regulatory requirements or\nrisk assessment.</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ICHQ3R8\">[ICH Q3(R8) Guideline for Elemental Impurities]</a></p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_pesticide_residues\">5.2.3. Pesticide residues</h4>\n<div class=\"paragraph\">\n<p>Pesticide residue testing shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Include pesticides commonly used in cultivation of the species</p>\n</li>\n<li>\n<p>Consider pesticides from previous land use</p>\n</li>\n<li>\n<p>Comply with regulatory limits for the intended market</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_mycotoxins\">5.2.4. Mycotoxins</h4>\n<div class=\"paragraph\">\n<p>Mycotoxin testing shall be performed when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Material is susceptible to fungal contamination</p>\n</li>\n<li>\n<p>Storage conditions may promote fungal growth</p>\n</li>\n<li>\n<p>Regulatory requirements apply</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Common mycotoxins to be tested include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Aflatoxins (B1, B2, G1, G2)</p>\n</li>\n<li>\n<p>Ochratoxin A</p>\n</li>\n<li>\n<p>Fumonisins</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_microbiological_contamination\">5.2.5. Microbiological contamination</h4>\n<div class=\"paragraph\">\n<p>Microbiological testing shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Total aerobic microbial count</p>\n</li>\n<li>\n<p>Yeast and mold count</p>\n</li>\n<li>\n<p>Specified pathogenic organisms</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance criteria shall be based on intended use and regulatory requirements.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_solvent_residues\">5.2.6. Solvent residues</h4>\n<div class=\"paragraph\">\n<p>For extracts prepared using organic solvents, testing shall verify that\nresidual solvent levels are within acceptable limits.</p>\n</div>\n<table id=\"table-contaminants\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Purity testing requirements</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 35%;\">\n<col style=\"width: 40%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Contaminant</th>\n<th class=\"tableblock halign-left valign-top\">Test method</th>\n<th class=\"tableblock halign-left valign-top\">Acceptance criteria</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Foreign matter</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Visual/manual separation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pharmacopoeial limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Heavy metals</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">ICP-MS, AAS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">ICH Q3D limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pesticides</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">GC-MS, LC-MS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Regulatory limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Mycotoxins</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">HPLC, LC-MS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Regulatory limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Microbiology</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Plate count, PCR</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pharmacopoeial limits</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"potency\">6. Potency determination</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-potency-general\">6.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Potency determination quantifies the concentration of active constituents or\nmarker compounds in plant materials and preparations.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-analyte-selection\">6.2. Analyte selection</h3>\n<div class=\"sect3\">\n<h4 id=\"_active_constituents\">6.2.1. Active constituents</h4>\n<div class=\"paragraph\">\n<p>When known active constituents are identified:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Quantification of active constituents is preferred</p>\n</li>\n<li>\n<p>Multiple actives may be quantified when relevant to efficacy</p>\n</li>\n<li>\n<p>Bioactive fractions may be quantified as a group</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_marker_compounds\">6.2.2. Marker compounds</h4>\n<div class=\"paragraph\">\n<p>When active constituents are not fully characterized:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Characteristic or analytical markers may be used</p>\n</li>\n<li>\n<p>The relationship between markers and activity shall be documented</p>\n</li>\n<li>\n<p>Selection of markers shall be scientifically justified</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-methods\">6.3. Quantitative methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_chromatographic_methods_2\">6.3.1. Chromatographic methods</h4>\n<div class=\"paragraph\">\n<p>Chromatographic methods for potency determination shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Be validated for specificity, accuracy, precision, linearity, and range</p>\n</li>\n<li>\n<p>Use reference standards of known purity</p>\n</li>\n<li>\n<p>Include system suitability tests</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_spectrophotometric_methods\">6.3.2. Spectrophotometric methods</h4>\n<div class=\"paragraph\">\n<p>Spectrophotometric methods may be used when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Chromatographic methods are not practical</p>\n</li>\n<li>\n<p>The analyte or analyte group has characteristic absorption</p>\n</li>\n<li>\n<p>Interference from other components has been evaluated</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-specifications\">6.4. Specifications</h3>\n<div class=\"paragraph\">\n<p>Acceptance criteria for potency shall be established based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Historical data for the species</p>\n</li>\n<li>\n<p>Phytochemical variability</p>\n</li>\n<li>\n<p>Clinical or traditional use information</p>\n</li>\n<li>\n<p>Manufacturing requirements</p>\n</li>\n</ul>\n</div>\n<table id=\"table-specification-example\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 3. Example specification format</caption>\n<colgroup>\n<col style=\"width: 50%;\">\n<col style=\"width: 50%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Parameter</th>\n<th class=\"tableblock halign-left valign-top\">Acceptance criteria</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Marker compound A</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 2.0% and NMT 4.0% (dry basis)</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Marker compound B</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 0.5% (dry basis)</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Total phenolics (as gallic acid)</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 5.0% (dry basis)</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"validation\">7. Method validation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-validation-requirements\">7.1. Validation requirements</h3>\n<div class=\"paragraph\">\n<p>Analytical methods shall be validated before use in quality control testing.\nValidation shall be documented and shall demonstrate that the method is fit\nfor its intended purpose.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-validation-parameters\">7.2. Validation parameters</h3>\n<div class=\"paragraph\">\n<p>Validation shall address the parameters specified in <a href=\"#table-validation-params\">Method validation parameters by test type</a>,\nas applicable to the method type.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-protocol\">7.3. Validation protocol</h3>\n<div class=\"paragraph\">\n<p>A validation protocol shall be prepared that includes:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Objective of the validation</p>\n</li>\n<li>\n<p>Description of the analytical procedure</p>\n</li>\n<li>\n<p>Parameters to be evaluated</p>\n</li>\n<li>\n<p>Acceptance criteria for each parameter</p>\n</li>\n<li>\n<p>Experimental design and sample requirements</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-report\">7.4. Validation report</h3>\n<div class=\"paragraph\">\n<p>A validation report shall be prepared that includes:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Summary of validation experiments performed</p>\n</li>\n<li>\n<p>Raw data and statistical analysis</p>\n</li>\n<li>\n<p>Comparison of results to acceptance criteria</p>\n</li>\n<li>\n<p>Conclusion on method suitability</p>\n</li>\n<li>\n<p>Any deviations from the protocol and their impact</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-revalidation\">7.5. Revalidation</h3>\n<div class=\"paragraph\">\n<p>Methods shall be revalidated when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Changes are made to the analytical procedure</p>\n</li>\n<li>\n<p>The method is transferred to another laboratory</p>\n</li>\n<li>\n<p>Results indicate the method is no longer performing adequately</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"reporting\">8. Reporting of results</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-report-content\">8.1. Certificate of analysis</h3>\n<div class=\"paragraph\">\n<p>A certificate of analysis shall be provided for each batch tested, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Identity of the material tested</p>\n</li>\n<li>\n<p>Batch or lot number</p>\n</li>\n<li>\n<p>Date of testing</p>\n</li>\n<li>\n<p>Reference to test methods used</p>\n</li>\n<li>\n<p>Test results with units</p>\n</li>\n<li>\n<p>Acceptance criteria</p>\n</li>\n<li>\n<p>Pass/fail determination</p>\n</li>\n<li>\n<p>Name and signature of authorized person</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-result-expression\">8.2. Expression of results</h3>\n<div class=\"paragraph\">\n<p>Results shall be expressed:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>In appropriate units (e.g., % w/w, mg/g, ppm)</p>\n</li>\n<li>\n<p>On a consistent basis (dry weight or as-is)</p>\n</li>\n<li>\n<p>With appropriate significant figures</p>\n</li>\n<li>\n<p>With measurement uncertainty when required</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-records\">8.3. Record retention</h3>\n<div class=\"paragraph\">\n<p>Analytical records shall be retained for a period defined by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Regulatory requirements</p>\n</li>\n<li>\n<p>Product shelf life</p>\n</li>\n<li>\n<p>Quality management system requirements</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nA minimum retention period of one year beyond product shelf life is\nrecommended.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[[[ICHQ2R1,ICH Q2(R1) Validation of Analytical Procedures: Text and\nMethodology]]]</p>\n</li>\n<li>\n<p><a id=\"FDAGuidance\"></a>[FDA Guidance for Industry: Botanical Drug Development],\nU.S. Food and Drug Administration, 2016</p>\n</li>\n<li>\n<p><a id=\"EMAGuidance\"></a>[EMA Guideline on Quality of Herbal Medicinal Products],\nEuropean Medicines Agency</p>\n</li>\n<li>\n<p><a id=\"AOAC\"></a>[AOAC Official Methods of Analysis], Association of Official\nAnalytical Chemists</p>\n</li>\n<li>\n<p><a id=\"ICHQ3D\"></a>[ICH Q3D Guideline for Elemental Impurities]</p>\n</li>\n<li>\n<p>[[[USP2232,USP General Chapter &lt;2232&gt; Elemental Contaminants in Dietary\nSupplements]]]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_analytical_procedure",
+          "title": "analytical procedure",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_method_validation",
+          "title": "method validation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_specificity",
+          "title": "specificity",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_accuracy",
+          "title": "accuracy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_precision",
+          "title": "precision",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_repeatability",
+          "title": "repeatability",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_intermediate_precision",
+          "title": "intermediate precision",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_reproducibility",
+          "title": "reproducibility",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_limit_of_detection",
+          "title": "limit of detection",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_limit_of_quantitation",
+          "title": "limit of quantitation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_linearity",
+          "title": "linearity",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_range",
+          "title": "range",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_robustness",
+          "title": "robustness",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_reference_standard",
+          "title": "reference standard",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_system_suitability",
+          "title": "system suitability",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "identity",
+      "title": "Identity testing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-identity-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_methods_of_identity_testing",
+          "title": "Methods of identity testing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_macroscopic_examination",
+              "title": "Macroscopic examination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_microscopic_examination",
+              "title": "Microscopic examination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_chromatographic_methods",
+              "title": "Chromatographic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_spectroscopic_methods",
+              "title": "Spectroscopic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_dna_based_methods",
+              "title": "DNA-based methods",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-identity-acceptance",
+          "title": "Acceptance criteria",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "purity",
+      "title": "Purity testing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-purity-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-contaminants",
+          "title": "Contaminant categories",
+          "level": 2,
+          "children": [
+            {
+              "id": "_foreign_matter",
+              "title": "Foreign matter",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_heavy_metals",
+              "title": "Heavy metals",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_pesticide_residues",
+              "title": "Pesticide residues",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_mycotoxins",
+              "title": "Mycotoxins",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_microbiological_contamination",
+              "title": "Microbiological contamination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_solvent_residues",
+              "title": "Solvent residues",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "potency",
+      "title": "Potency determination",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-potency-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-analyte-selection",
+          "title": "Analyte selection",
+          "level": 2,
+          "children": [
+            {
+              "id": "_active_constituents",
+              "title": "Active constituents",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_marker_compounds",
+              "title": "Marker compounds",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-methods",
+          "title": "Quantitative methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_chromatographic_methods_2",
+              "title": "Chromatographic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_spectrophotometric_methods",
+              "title": "Spectrophotometric methods",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-specifications",
+          "title": "Specifications",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "validation",
+      "title": "Method validation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-validation-requirements",
+          "title": "Validation requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-validation-parameters",
+          "title": "Validation parameters",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-protocol",
+          "title": "Validation protocol",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-report",
+          "title": "Validation report",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-revalidation",
+          "title": "Revalidation",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "reporting",
+      "title": "Reporting of results",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-report-content",
+          "title": "Certificate of analysis",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-result-expression",
+          "title": "Expression of results",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-records",
+          "title": "Record retention",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Analytical Methods for Phytomedicine\n:docnumber: 0300\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Analytical Methods for Phytomedicine\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 4\n:technical-committee: Analytical Methods\n:library-ics: 07.100.01;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-identity.adoc[]\n\ninclude::sections/05-purity.adoc[]\n\ninclude::sections/06-potency.adoc[]\n\ninclude::sections/07-validation.adoc[]\n\ninclude::sections/08-reporting.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/public/content/standards/SIPM-0400.json
+++ b/public/content/standards/SIPM-0400.json
@@ -1,0 +1,303 @@
+{
+  "id": "SIPM-0400",
+  "title": "Clinical Evidence for Phytomedicine",
+  "attributes": {
+    "docnumber": "0400",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Clinical Evidence for Phytomedicine",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Clinical Evidence",
+    "library-ics": "11.120.10;03.100.01"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_clinical_evidence\">3.1. clinical evidence</a></li>\n<li><a href=\"#_clinical_trial\">3.2. clinical trial</a></li>\n<li><a href=\"#_randomized_controlled_trial\">3.3. randomized controlled trial</a></li>\n<li><a href=\"#_observational_study\">3.4. observational study</a></li>\n<li><a href=\"#_systematic_review\">3.5. systematic review</a></li>\n<li><a href=\"#_meta_analysis\">3.6. meta-analysis</a></li>\n<li><a href=\"#_traditional_use_evidence\">3.7. traditional use evidence</a></li>\n<li><a href=\"#_well_established_use\">3.8. well-established use</a></li>\n<li><a href=\"#_efficacy\">3.9. efficacy</a></li>\n<li><a href=\"#_effectiveness\">3.10. effectiveness</a></li>\n<li><a href=\"#_safety_profile\">3.11. safety profile</a></li>\n<li><a href=\"#_pharmacovigilance\">3.12. pharmacovigilance</a></li>\n<li><a href=\"#_investigational_product\">3.13. investigational product</a></li>\n</ul>\n</li>\n<li><a href=\"#evidence-hierarchy\">4. Evidence hierarchy</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-evidence-levels\">4.1. Levels of evidence</a></li>\n<li><a href=\"#sec-evidence-weighting\">4.2. Evidence weighting</a></li>\n<li><a href=\"#sec-traditional-evidence\">4.3. Traditional use evidence</a></li>\n</ul>\n</li>\n<li><a href=\"#study-design\">5. Study design considerations</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-product-characterization\">5.1. Product characterization</a></li>\n<li><a href=\"#sec-study-population\">5.2. Study population</a></li>\n<li><a href=\"#sec-outcome-measures\">5.3. Outcome measures</a></li>\n<li><a href=\"#sec-control-interventions\">5.4. Control interventions</a></li>\n<li><a href=\"#sec-study-duration\">5.5. Study duration</a></li>\n</ul>\n</li>\n<li><a href=\"#quality-assessment\">6. Quality assessment of clinical studies</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-quality-criteria\">6.1. Quality criteria</a></li>\n<li><a href=\"#sec-quality-domains\">6.2. Quality domains for RCTs</a></li>\n<li><a href=\"#sec-transparency\">6.3. Transparency requirements</a></li>\n</ul>\n</li>\n<li><a href=\"#reporting\">7. Reporting standards</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-reporting-guidelines\">7.1. Reporting guidelines</a></li>\n<li><a href=\"#sec-reporting-elements\">7.2. Essential reporting elements</a></li>\n<li><a href=\"#sec-data-sharing\">7.3. Data sharing</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 5,\n<em>Clinical Evidence</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0400.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0400 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The establishment of clinical evidence is fundamental to the responsible use of\nphytomedicine in healthcare. While traditional use provides valuable historical\ncontext, modern evidence-based practice requires rigorous clinical research to\nestablish safety and efficacy.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document provides a framework for the generation, evaluation, and reporting\nof clinical evidence for phytomedicine products. It recognizes the unique\nchallenges of clinical research in phytomedicine, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Complexity of multi-component botanical preparations</p>\n</li>\n<li>\n<p>Variability in product composition between studies</p>\n</li>\n<li>\n<p>Integration of traditional knowledge with modern research methods</p>\n</li>\n<li>\n<p>Ethical considerations in studying traditional remedies</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses the complete evidence generation process:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Classification of evidence types and their relative weight</p>\n</li>\n<li>\n<p>Study design considerations specific to phytomedicine</p>\n</li>\n<li>\n<p>Quality assessment of clinical studies</p>\n</li>\n<li>\n<p>Transparent reporting of methods and results</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to support:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Researchers designing clinical studies of phytomedicines</p>\n</li>\n<li>\n<p>Regulatory bodies evaluating marketing authorization applications</p>\n</li>\n<li>\n<p>Healthcare professionals assessing evidence for clinical practice</p>\n</li>\n<li>\n<p>Manufacturers developing evidence-based products</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the generation, evaluation, and\nreporting of clinical evidence for phytomedicine products.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clinical trials and observational studies of phytomedicines</p>\n</li>\n<li>\n<p>Evidence synthesis and systematic reviews</p>\n</li>\n<li>\n<p>Assessment of traditional use evidence</p>\n</li>\n<li>\n<p>Regulatory submissions and health claims substantiation</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Herbal medicinal products</p>\n</li>\n<li>\n<p>Medicinal fungi products</p>\n</li>\n<li>\n<p>Traditional herbal preparations</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Preclinical (in vitro and animal) studies</p>\n</li>\n<li>\n<p>Specific disease conditions or products</p>\n</li>\n<li>\n<p>Regulatory requirements for specific jurisdictions</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICHGCP\"></a>[ICH E6(R2) Good Clinical Practice]</p>\n</li>\n<li>\n<p>[[[CONSORT,CONSORT 2010 Statement: Updated Guidelines for Reporting Parallel\nGroup Randomized Trials]]]</p>\n</li>\n<li>\n<p><a id=\"PRISMA\"></a>[PRISMA Statement for Reporting Systematic Reviews]</p>\n</li>\n<li>\n<p>[[[GRADE,Grading of Recommendations Assessment, Development and Evaluation\n(GRADE) Handbook]]]</p>\n</li>\n<li>\n<p>[[[WHOTM,WHO General Guidelines for Methodologies on Research and Evaluation\nof Traditional Medicine]]]</p>\n</li>\n<li>\n<p>[[[DECLHELSINKI,Declaration of Helsinki: Ethical Principles for Medical\nResearch Involving Human Subjects]]]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_clinical_evidence\">3.1. clinical evidence</h3>\n<div class=\"paragraph\">\n<p>information derived from clinical research that contributes to the assessment\nof safety and efficacy of a phytomedicine</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_clinical_trial\">3.2. clinical trial</h3>\n<div class=\"paragraph\">\n<p>alt:[interventional study]</p>\n</div>\n<div class=\"paragraph\">\n<p>research study that prospectively assigns human participants to one or more\ninterventions to evaluate the effects on health outcomes</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_randomized_controlled_trial\">3.3. randomized controlled trial</h3>\n<div class=\"paragraph\">\n<p>alt:[RCT]</p>\n</div>\n<div class=\"paragraph\">\n<p>clinical trial in which participants are allocated to intervention groups by\nchance (randomization)</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_observational_study\">3.4. observational study</h3>\n<div class=\"paragraph\">\n<p>research study in which participants are observed and outcomes measured without\nassignment of interventions by the investigator</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_systematic_review\">3.5. systematic review</h3>\n<div class=\"paragraph\">\n<p>review that uses systematic methods to identify, select, and critically\nappraise relevant research, and to collect and analyze data from included studies</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_meta_analysis\">3.6. meta-analysis</h3>\n<div class=\"paragraph\">\n<p>statistical analysis that combines the results of multiple scientific studies</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traditional_use_evidence\">3.7. traditional use evidence</h3>\n<div class=\"paragraph\">\n<p>documentation of the historical use of a phytomedicine over one or more\ngenerations within a specific cultural context</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_well_established_use\">3.8. well-established use</h3>\n<div class=\"paragraph\">\n<p>regulatory concept referring to a medicinal product with recognized safety and\nefficacy based on at least 10 years of use in a specific jurisdiction</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_efficacy\">3.9. efficacy</h3>\n<div class=\"paragraph\">\n<p>ability of a phytomedicine to produce a beneficial therapeutic effect under\ncontrolled conditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_effectiveness\">3.10. effectiveness</h3>\n<div class=\"paragraph\">\n<p>degree to which a phytomedicine produces a beneficial effect under real-world\nconditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_safety_profile\">3.11. safety profile</h3>\n<div class=\"paragraph\">\n<p>comprehensive summary of known and potential adverse effects, contraindications,\nand drug interactions associated with a phytomedicine</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacovigilance\">3.12. pharmacovigilance</h3>\n<div class=\"paragraph\">\n<p>science and activities relating to the detection, assessment, understanding,\nand prevention of adverse effects or other drug-related problems</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_investigational_product\">3.13. investigational product</h3>\n<div class=\"paragraph\">\n<p>phytomedicine being tested or used as a reference in a clinical trial</p>\n</div>\n<table id=\"table-study-types\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Characteristics of common study designs</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 45%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Study type</th>\n<th class=\"tableblock halign-left valign-top\">Key features</th>\n<th class=\"tableblock halign-left valign-top\">Strengths/limitations</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trial</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Random allocation, control group, blinding</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">High internal validity; may have limited external validity</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized controlled trial</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Control group without randomization</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Practical for some settings; potential for confounding</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cohort study</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Follows groups over time</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Good for rare exposures; potential for confounding</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case-control study</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compares cases with controls</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Good for rare outcomes; recall bias</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case series</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Description of multiple cases</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hypothesis generation; no control group</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"evidence-hierarchy\">4. Evidence hierarchy</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-evidence-levels\">4.1. Levels of evidence</h3>\n<div class=\"paragraph\">\n<p>Evidence for phytomedicine safety and efficacy shall be classified according\nto a hierarchical system that reflects the relative strength of different\nevidence types.</p>\n</div>\n<table id=\"table-evidence-levels\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Evidence hierarchy for phytomedicine</caption>\n<colgroup>\n<col style=\"width: 15%;\">\n<col style=\"width: 25%;\">\n<col style=\"width: 60%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Level</th>\n<th class=\"tableblock halign-left valign-top\">Evidence type</th>\n<th class=\"tableblock halign-left valign-top\">Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level I</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Systematic reviews of RCTs</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Meta-analyses and systematic reviews of randomized controlled trials</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level II</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trials</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Well-designed randomized controlled trials with adequate sample size</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level III</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized controlled studies</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Controlled studies without randomization, cohort studies</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level IV</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case series and case reports</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Uncontrolled studies, case series, case reports</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level V</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Traditional use evidence</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Documented historical use, ethnobotanical records, traditional knowledge</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-evidence-weighting\">4.2. Evidence weighting</h3>\n<div class=\"paragraph\">\n<p>When evaluating the totality of evidence, the following factors shall be\nconsidered:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Study design (higher levels provide stronger evidence)</p>\n</li>\n<li>\n<p>Methodological quality of individual studies</p>\n</li>\n<li>\n<p>Consistency of findings across studies</p>\n</li>\n<li>\n<p>Directness of evidence to the population and intervention of interest</p>\n</li>\n<li>\n<p>Precision of effect estimates</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-traditional-evidence\">4.3. Traditional use evidence</h3>\n<div class=\"paragraph\">\n<p>Traditional use evidence may be considered as supporting evidence when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>The phytomedicine has been used for a defined period (typically 30+ years)</p>\n</li>\n<li>\n<p>The conditions of use (dose, route, population) are documented</p>\n</li>\n<li>\n<p>Safety information is available from traditional use</p>\n</li>\n<li>\n<p>The traditional preparation method is relevant to the modern product</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTraditional use evidence alone is generally insufficient to support\nefficacy claims in most regulatory jurisdictions, but may support safety\nand guide clinical research design.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"study-design\">5. Study design considerations</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-product-characterization\">5.1. Product characterization</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_and_quality\">5.1.1. Identity and quality</h4>\n<div class=\"paragraph\">\n<p>The investigational phytomedicine product shall be fully characterized,\nincluding:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Botanical identity (species, plant part, geographic origin)</p>\n</li>\n<li>\n<p>Manufacturing process and quality control</p>\n</li>\n<li>\n<p>Phytochemical profile (marker compounds, batch-to-batch consistency)</p>\n</li>\n<li>\n<p>Specifications and certificate of analysis</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nPoor product characterization is a common limitation of published\nphytomedicine clinical studies.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_standardization\">5.1.2. Standardization</h4>\n<div class=\"paragraph\">\n<p>When applicable, the study product shall be standardized to defined marker\ncompounds or active constituents.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-study-population\">5.2. Study population</h3>\n<div class=\"sect3\">\n<h4 id=\"_participant_selection\">5.2.1. Participant selection</h4>\n<div class=\"paragraph\">\n<p>The study population shall be defined by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Inclusion criteria appropriate to the research question</p>\n</li>\n<li>\n<p>Exclusion criteria that address safety concerns</p>\n</li>\n<li>\n<p>Relevant demographic and clinical characteristics</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_sample_size\">5.2.2. Sample size</h4>\n<div class=\"paragraph\">\n<p>Sample size calculations shall be performed and documented, based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Expected effect size</p>\n</li>\n<li>\n<p>Variability in primary outcome measures</p>\n</li>\n<li>\n<p>Statistical power requirements</p>\n</li>\n<li>\n<p>Significance level</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-outcome-measures\">5.3. Outcome measures</h3>\n<div class=\"sect3\">\n<h4 id=\"_primary_outcomes\">5.3.1. Primary outcomes</h4>\n<div class=\"paragraph\">\n<p>Primary outcomes shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Be clinically relevant to the indication</p>\n</li>\n<li>\n<p>Be valid, reliable, and responsive to change</p>\n</li>\n<li>\n<p>Be specified a priori in the study protocol</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_secondary_outcomes\">5.3.2. Secondary outcomes</h4>\n<div class=\"paragraph\">\n<p>Secondary outcomes may include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Additional clinical measures</p>\n</li>\n<li>\n<p>Quality of life assessments</p>\n</li>\n<li>\n<p>Biomarkers</p>\n</li>\n<li>\n<p>Safety outcomes</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-control-interventions\">5.4. Control interventions</h3>\n<div class=\"paragraph\">\n<p>Control interventions may include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Placebo (when ethically appropriate)</p>\n</li>\n<li>\n<p>Active comparator (standard treatment)</p>\n</li>\n<li>\n<p>No treatment (for pragmatic trials)</p>\n</li>\n<li>\n<p>Dose comparison</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Placebo control shall match the investigational product in appearance, taste,\nand smell where possible.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-study-duration\">5.5. Study duration</h3>\n<div class=\"paragraph\">\n<p>Study duration shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Appropriate to the indication and expected time to effect</p>\n</li>\n<li>\n<p>Sufficient to detect both efficacy and safety signals</p>\n</li>\n<li>\n<p>Justified in the study protocol</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>For chronic conditions, long-term safety data (6+ months) is typically required.</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"quality-assessment\">6. Quality assessment of clinical studies</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-quality-criteria\">6.1. Quality criteria</h3>\n<div class=\"paragraph\">\n<p>The methodological quality of clinical studies shall be assessed using\nvalidated assessment tools appropriate to the study design.</p>\n</div>\n<table id=\"table-quality-tools\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 3. Quality assessment tools by study design</caption>\n<colgroup>\n<col style=\"width: 40%;\">\n<col style=\"width: 60%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Study design</th>\n<th class=\"tableblock halign-left valign-top\">Assessment tool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trials</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cochrane Risk of Bias tool, Jadad scale</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized studies</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Newcastle-Ottawa Scale, ROBINS-I</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Systematic reviews</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">AMSTAR 2, ROBIS</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-quality-domains\">6.2. Quality domains for RCTs</h3>\n<div class=\"paragraph\">\n<p>Quality assessment of randomized controlled trials shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Random sequence generation</p>\n</li>\n<li>\n<p>Allocation concealment</p>\n</li>\n<li>\n<p>Blinding of participants and personnel</p>\n</li>\n<li>\n<p>Blinding of outcome assessment</p>\n</li>\n<li>\n<p>Incomplete outcome data</p>\n</li>\n<li>\n<p>Selective reporting</p>\n</li>\n<li>\n<p>Other sources of bias</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-transparency\">6.3. Transparency requirements</h3>\n<div class=\"paragraph\">\n<p>To support quality assessment, clinical studies shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Registered in a public trials registry before enrollment</p>\n</li>\n<li>\n<p>Conducted in accordance with Good Clinical Practice (GCP)</p>\n</li>\n<li>\n<p>Reported completely and transparently</p>\n</li>\n<li>\n<p>Made available through open access when possible</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"reporting\">7. Reporting standards</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-reporting-guidelines\">7.1. Reporting guidelines</h3>\n<div class=\"paragraph\">\n<p>Clinical studies of phytomedicines shall be reported in accordance with\nrecognized reporting guidelines:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>CONSORT for randomized controlled trials</p>\n</li>\n<li>\n<p>STROBE for observational studies</p>\n</li>\n<li>\n<p>PRISMA for systematic reviews</p>\n</li>\n<li>\n<p>TREND for non-randomized evaluations</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-reporting-elements\">7.2. Essential reporting elements</h3>\n<div class=\"paragraph\">\n<p>Reports of phytomedicine clinical studies shall include:</p>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_product_information\">7.2.1. Product information</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Complete botanical identification (species, authority, plant part)</p>\n</li>\n<li>\n<p>Extract type and method of preparation</p>\n</li>\n<li>\n<p>Drug-to-extract ratio (for extracts)</p>\n</li>\n<li>\n<p>Standardization information (marker compounds and levels)</p>\n</li>\n<li>\n<p>Dose and dosing regimen</p>\n</li>\n<li>\n<p>Manufacturer and batch numbers</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_study_methods\">7.2.2. Study methods</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Study design and justification</p>\n</li>\n<li>\n<p>Participant eligibility criteria</p>\n</li>\n<li>\n<p>Interventions for each group</p>\n</li>\n<li>\n<p>Outcome measures and timing</p>\n</li>\n<li>\n<p>Sample size calculation</p>\n</li>\n<li>\n<p>Randomization and blinding methods</p>\n</li>\n<li>\n<p>Statistical methods</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_results\">7.2.3. Results</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Participant flow (recruitment, allocation, follow-up, analysis)</p>\n</li>\n<li>\n<p>Baseline characteristics</p>\n</li>\n<li>\n<p>Results for primary and secondary outcomes</p>\n</li>\n<li>\n<p>Harms and adverse events</p>\n</li>\n<li>\n<p>Limitations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-data-sharing\">7.3. Data sharing</h3>\n<div class=\"paragraph\">\n<p>To support evidence synthesis and transparency:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Individual participant data should be made available where possible</p>\n</li>\n<li>\n<p>Study protocols and statistical analysis plans should be published</p>\n</li>\n<li>\n<p>Negative and inconclusive results should be reported</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[<a id=\"CONSORT2010\"></a>, CONSORT 2010 Statement: Updated guidelines for\nreporting parallel group randomized trials. <em>BMJ</em> 2010, <strong>340</strong>, c332</p>\n</li>\n<li>\n<p>[<a id=\"GRADEhandbook\"></a>, <em>GRADE Handbook</em>. Cochrane, 2013</p>\n</li>\n<li>\n<p>[[[FWHO2000,WHO General Guidelines for Methodologies on Research and\nEvaluation of Traditional Medicine]]], World Health Organization, Geneva, 2000</p>\n</li>\n<li>\n<p>[[[EichEich D.#]], Clinical trials in phytomedicine: Challenges and\nopportunities. <em>Phytomedicine</em> 2015, <strong>22</strong> (12) pp. 1061-1065</p>\n</li>\n<li>\n<p>[[[GagnierGagnier J.J.#]], Improving the quality of reporting of randomized\ncontrolled trials in phytomedicine. <em>Phytomedicine</em> 2006, <strong>13</strong> (4) pp. 274-282</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_clinical_evidence",
+          "title": "clinical evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_clinical_trial",
+          "title": "clinical trial",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_randomized_controlled_trial",
+          "title": "randomized controlled trial",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_observational_study",
+          "title": "observational study",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_systematic_review",
+          "title": "systematic review",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_meta_analysis",
+          "title": "meta-analysis",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traditional_use_evidence",
+          "title": "traditional use evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_well_established_use",
+          "title": "well-established use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_efficacy",
+          "title": "efficacy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_effectiveness",
+          "title": "effectiveness",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_safety_profile",
+          "title": "safety profile",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacovigilance",
+          "title": "pharmacovigilance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_investigational_product",
+          "title": "investigational product",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "evidence-hierarchy",
+      "title": "Evidence hierarchy",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-evidence-levels",
+          "title": "Levels of evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-evidence-weighting",
+          "title": "Evidence weighting",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-traditional-evidence",
+          "title": "Traditional use evidence",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "study-design",
+      "title": "Study design considerations",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-product-characterization",
+          "title": "Product characterization",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_and_quality",
+              "title": "Identity and quality",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_standardization",
+              "title": "Standardization",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-study-population",
+          "title": "Study population",
+          "level": 2,
+          "children": [
+            {
+              "id": "_participant_selection",
+              "title": "Participant selection",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_sample_size",
+              "title": "Sample size",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-outcome-measures",
+          "title": "Outcome measures",
+          "level": 2,
+          "children": [
+            {
+              "id": "_primary_outcomes",
+              "title": "Primary outcomes",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_secondary_outcomes",
+              "title": "Secondary outcomes",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-control-interventions",
+          "title": "Control interventions",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-study-duration",
+          "title": "Study duration",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "quality-assessment",
+      "title": "Quality assessment of clinical studies",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-quality-criteria",
+          "title": "Quality criteria",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-quality-domains",
+          "title": "Quality domains for RCTs",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-transparency",
+          "title": "Transparency requirements",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "reporting",
+      "title": "Reporting standards",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-reporting-guidelines",
+          "title": "Reporting guidelines",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-reporting-elements",
+          "title": "Essential reporting elements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_product_information",
+              "title": "Product information",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_study_methods",
+              "title": "Study methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_results",
+              "title": "Results",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-data-sharing",
+          "title": "Data sharing",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Clinical Evidence for Phytomedicine\n:docnumber: 0400\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Clinical Evidence for Phytomedicine\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 5\n:technical-committee: Clinical Evidence\n:library-ics: 11.120.10;03.100.01\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-evidence-hierarchy.adoc[]\n\ninclude::sections/05-study-design.adoc[]\n\ninclude::sections/06-quality-assessment.adoc[]\n\ninclude::sections/07-reporting.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/public/content/standards/index.json
+++ b/public/content/standards/index.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "SIPM-0001",
+    "title": "Terminology for Phytomedicine",
+    "number": "SIPM-0001",
+    "category": "foundation",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0002",
+    "title": "Medicinal Fungi Taxonomy",
+    "number": "SIPM-0002",
+    "category": "foundation",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0200",
+    "title": "Agricultural Practices for Medicinal Plants",
+    "number": "SIPM-0200",
+    "category": "quality",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0300",
+    "title": "Analytical Methods for Phytomedicine",
+    "number": "SIPM-0300",
+    "category": "science",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0400",
+    "title": "Clinical Evidence for Phytomedicine",
+    "number": "SIPM-0400",
+    "category": "science",
+    "status": "published",
+    "date": "2026-02-17"
+  }
+]

--- a/scripts/build-standards.js
+++ b/scripts/build-standards.js
@@ -1,0 +1,147 @@
+/**
+ * Build script to convert AsciiDoc standards to JSON
+ * Run: node scripts/build-standards.js
+ */
+
+import { readdir, readFile, writeFile, mkdir } from 'fs/promises'
+import { join, basename, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import Asciidoctor from '@asciidoctor/core'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const asciidoctor = Asciidoctor()
+
+// Allow overriding standards path via environment variable (for CI)
+const STANDARDS_SRC = process.env.STANDARDS_PATH || join(__dirname, '../../standards')
+const OUTPUT_DIR = join(__dirname, '../src/content/standards')
+const PUBLIC_DIR = join(__dirname, '../public/content/standards')
+
+// Parse AsciiDoc and extract structured content
+function parseAdocFile(content, filePath) {
+  const baseDir = dirname(filePath)
+
+  const doc = asciidoctor.load(content, {
+    base_dir: baseDir,
+    safe: 'safe',
+    attributes: {
+      'skip-front-matter': true,
+      'sectnums': true,
+      'toc': 'left',
+      'linkcss': false,
+      'copycss': false
+    }
+  })
+
+  // Extract document attributes
+  const attributes = {}
+  const attrNames = [
+    'docnumber', 'partnumber', 'edition', 'revdate', 'copyright-year',
+    'language', 'title-intro-en', 'title-main-en', 'title-part-en',
+    'doctype', 'docstage', 'docsubstage', 'technical-committee',
+    'workgroup', 'library-ics'
+  ]
+
+  for (const name of attrNames) {
+    const value = doc.getAttribute(name)
+    if (value) attributes[name] = value
+  }
+
+  // Build title
+  const title = doc.getTitle() || attributes['title-main-en'] || 'Untitled Standard'
+
+  // Convert to HTML with full content
+  const html = doc.convert()
+
+  // Extract sections for TOC
+  function extractSections(blocks) {
+    const sections = []
+    for (const block of blocks) {
+      if (block.getContext() === 'section') {
+        const section = {
+          id: block.getId(),
+          title: block.getTitle(),
+          level: block.getLevel(),
+          children: extractSections(block.getBlocks())
+        }
+        sections.push(section)
+      }
+    }
+    return sections
+  }
+
+  const toc = extractSections(doc.getBlocks())
+
+  return {
+    id: basename(dirname(filePath)),
+    title,
+    attributes,
+    html,
+    toc,
+    raw: content
+  }
+}
+
+async function processStandards() {
+  console.log('Building standards content...')
+
+  // Ensure output directories exist
+  await mkdir(OUTPUT_DIR, { recursive: true })
+  await mkdir(PUBLIC_DIR, { recursive: true })
+
+  const standards = []
+  const standardDirs = await readdir(STANDARDS_SRC)
+
+  for (const dir of standardDirs) {
+    if (!dir.startsWith('SIPM-')) continue
+
+    const standardPath = join(STANDARDS_SRC, dir, 'document.adoc')
+    try {
+      const content = await readFile(standardPath, 'utf-8')
+      const parsed = parseAdocFile(content, standardPath)
+
+      // Write individual standard JSON to both locations
+      const jsonStr = JSON.stringify(parsed, null, 2)
+
+      await writeFile(join(OUTPUT_DIR, `${dir}.json`), jsonStr)
+      await writeFile(join(PUBLIC_DIR, `${dir}.json`), jsonStr)
+
+      standards.push({
+        id: parsed.id,
+        title: parsed.title,
+        number: dir,
+        category: getCategory(dir),
+        status: parsed.attributes.docstage === '60' ? 'published' : 'draft',
+        date: parsed.attributes.revdate || new Date().toISOString().split('T')[0]
+      })
+
+      console.log(`  Processed: ${dir} - ${parsed.title}`)
+    } catch (err) {
+      console.log(`  Skipped: ${dir} (${err.message})`)
+    }
+  }
+
+  // Write index file to both locations
+  const indexJson = JSON.stringify(standards, null, 2)
+  await writeFile(join(OUTPUT_DIR, 'index.json'), indexJson)
+  await writeFile(join(PUBLIC_DIR, 'index.json'), indexJson)
+
+  console.log(`\nBuilt ${standards.length} standards to ${OUTPUT_DIR}`)
+  console.log(`Also copied to ${PUBLIC_DIR}`)
+
+  return standards
+}
+
+function getCategory(number) {
+  const num = parseInt(number.replace('SIPM-', ''))
+  if (num < 100) return 'foundation'
+  if (num < 200) return 'governance'
+  if (num < 300) return 'quality'
+  if (num < 400) return 'science'
+  if (num < 500) return 'science'
+  return 'governance'
+}
+
+// Run if called directly
+processStandards().catch(console.error)
+
+export { parseAdocFile, processStandards }

--- a/src/content/standards/SIPM-0001.json
+++ b/src/content/standards/SIPM-0001.json
@@ -1,0 +1,475 @@
+{
+  "id": "SIPM-0001",
+  "title": "Terminology for Phytomedicine",
+  "attributes": {
+    "docnumber": "0001",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Terminology for Phytomedicine",
+    "title-part-en": "General vocabulary",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Terminology and Nomenclature",
+    "library-ics": "01.040.11;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_phytomedicine\">3.1. phytomedicine</a></li>\n<li><a href=\"#_medicinal_plant\">3.2. medicinal plant</a></li>\n<li><a href=\"#_botanical_drug_product\">3.3. botanical drug product</a></li>\n<li><a href=\"#_herbal_preparation\">3.4. herbal preparation</a></li>\n<li><a href=\"#_herbal_substance\">3.5. herbal substance</a></li>\n<li><a href=\"#_active_pharmaceutical_ingredient\">3.6. active pharmaceutical ingredient</a></li>\n<li><a href=\"#_marker_compound\">3.7. marker compound</a></li>\n<li><a href=\"#_active_marker_compound\">3.8. active marker compound</a></li>\n<li><a href=\"#_characteristic_constituent\">3.9. characteristic constituent</a></li>\n<li><a href=\"#_standardized_extract\">3.10. standardized extract</a></li>\n<li><a href=\"#_quantified_extract\">3.11. quantified extract</a></li>\n<li><a href=\"#_native_extract\">3.12. native extract</a></li>\n<li><a href=\"#_processed_extract\">3.13. processed extract</a></li>\n<li><a href=\"#_extraction\">3.14. extraction</a></li>\n<li><a href=\"#_extraction_solvent\">3.15. extraction solvent</a></li>\n<li><a href=\"#_extraction_yield\">3.16. extraction yield</a></li>\n<li><a href=\"#_phytochemistry\">3.17. phytochemistry</a></li>\n<li><a href=\"#_pharmacognosy\">3.18. pharmacognosy</a></li>\n<li><a href=\"#_plant_part\">3.19. plant part</a></li>\n<li><a href=\"#_botanical_identification\">3.20. botanical identification</a></li>\n<li><a href=\"#_adulteration\">3.21. adulteration</a></li>\n<li><a href=\"#_contamination\">3.22. contamination</a></li>\n<li><a href=\"#_quality_control\">3.23. quality control</a></li>\n<li><a href=\"#_stability\">3.24. stability</a></li>\n<li><a href=\"#_shelf_life\">3.25. shelf life</a></li>\n<li><a href=\"#_good_agricultural_and_collection_practices\">3.26. good agricultural and collection practices</a></li>\n<li><a href=\"#_voucher_specimen\">3.27. voucher specimen</a></li>\n<li><a href=\"#_botanical_reference_material\">3.28. botanical reference material</a></li>\n<li><a href=\"#_therapeutic_indication\">3.29. therapeutic indication</a></li>\n<li><a href=\"#_contraindication\">3.30. contraindication</a></li>\n<li><a href=\"#_traditional_use\">3.31. traditional use</a></li>\n<li><a href=\"#_well_established_use\">3.32. well-established use</a></li>\n<li><a href=\"#_safety\">3.33. safety</a></li>\n<li><a href=\"#_efficacy\">3.34. efficacy</a></li>\n<li><a href=\"#_pharmacovigilance\">3.35. pharmacovigilance</a></li>\n<li><a href=\"#_herbal_drug_interaction\">3.36. herbal-drug interaction</a></li>\n</ul>\n</li>\n<li><a href=\"#vocabulary\">4. Additional vocabulary</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_extraction_and_processing\">4.1. Extraction and processing</a></li>\n<li><a href=\"#_quality_and_testing\">4.2. Quality and testing</a></li>\n<li><a href=\"#_dosage_forms\">4.3. Dosage forms</a></li>\n<li><a href=\"#_biological_and_cultivation\">4.4. Biological and cultivation</a></li>\n<li><a href=\"#_regulatory_and_classification\">4.5. Regulatory and classification</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 1,\n<em>Terminology and Nomenclature</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0001.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0001 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The field of phytomedicine encompasses the study and therapeutic use of plant-\nderived substances for the prevention and treatment of disease. As interest in\nnatural health products has grown globally, the need for standardized terminology\nhas become increasingly important to ensure clear communication among\nresearchers, healthcare practitioners, regulators, manufacturers, and consumers.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes a comprehensive vocabulary for phytomedicine that\nprovides a foundation for consistent use of terms across scientific literature,\nregulatory documents, product labels, and clinical communications. The\nterminology presented here has been developed through consensus among\ninternational experts in pharmacognosy, botany, chemistry, pharmacology,\ntoxicology, and clinical medicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>The terminology in this document is organized into two main sections:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clause 3 defines core concepts that are essential for understanding\nphytomedicine and its related fields</p>\n</li>\n<li>\n<p>Clause 4 provides additional vocabulary for specific domains within\nphytomedicine</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to serve as a reference for authors of scientific\npapers, developers of regulatory guidelines, manufacturers of phytomedicine\nproducts, and healthcare professionals who recommend or prescribe phytomedicines.</p>\n</div>\n<div class=\"paragraph\">\n<p>The development of this terminology standard reflects SIPM&#8217;s commitment to\nadvancing the scientific basis of phytomedicine while respecting traditional\nknowledge systems. The definitions provided here are designed to be precise\nenough for scientific use while remaining accessible to diverse stakeholders\nin the phytomedicine community.</p>\n</div>\n<div class=\"paragraph\">\n<p>Future revisions of this document will incorporate new terms as the field\nevolves and will refine existing definitions based on scientific advances and\nfeedback from users of the standard.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document defines terms and establishes a vocabulary for the field of\nphytomedicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Scientific research and publication in phytomedicine</p>\n</li>\n<li>\n<p>Development and communication of regulatory requirements</p>\n</li>\n<li>\n<p>Manufacturing, quality control, and quality assurance of phytomedicine products</p>\n</li>\n<li>\n<p>Clinical practice and patient communication</p>\n</li>\n<li>\n<p>Education and training in phytomedicine and related fields</p>\n</li>\n<li>\n<p>Trade and commerce of phytomedicine products and raw materials</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Detailed taxonomic classification of medicinal plants (addressed in\nSIPM-0002)</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Clinical protocols (addressed in SIPM-0400 series)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The terms defined in this document are intended to be used in conjunction with\nother SIPM standards and may be referenced by external standards and regulatory\ndocuments.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"WHOGMP\"></a>[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</p>\n</li>\n<li>\n<p><a id=\"WHOTERM\"></a>[WHO International Standard Terminologies on Traditional Medicine in the Western Pacific Region]</p>\n</li>\n<li>\n<p><a id=\"ICHQ3R8\"></a>[ICH Q3(R8) Guideline for Elemental Impurities]</p>\n</li>\n<li>\n<p><a id=\"ISO9000\"></a>[ISO 9000:2015]</p>\n</li>\n<li>\n<p><a id=\"ISO11095\"></a>[ISO 11095:1996]</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_phytomedicine\">3.1. phytomedicine</h3>\n<div class=\"paragraph\">\n<p>alt:[herbal medicine]\nalt:[plant medicine]</p>\n</div>\n<div class=\"paragraph\">\n<p>medicinal product whose active ingredients are exclusively derived from one or\nmore plants, algae, fungi, or lichens in processed or unprocessed form</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 1: Phytomedicines may contain plant parts, plant juices, plant extracts,\nor purified compounds isolated from plants.</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 2: In some regulatory contexts, the term \"herbal medicinal product\" is\nused synonymously.</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#WHOTERM\">page 35</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_medicinal_plant\">3.2. medicinal plant</h3>\n<div class=\"paragraph\">\n<p>plant species that contains substances which can be used for therapeutic\npurposes or which are precursors for the synthesis of useful drugs</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMedicinal plants may be used in their whole form or as a source of\nisolated compounds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_drug_product\">3.3. botanical drug product</h3>\n<div class=\"paragraph\">\n<p>alt:[botanical drug]</p>\n</div>\n<div class=\"paragraph\">\n<p>finished product that contains a botanical drug substance, generally as the\nactive ingredient, and is intended to diagnose, cure, treat, mitigate, or\nprevent disease</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nThis term is commonly used in regulatory contexts, particularly in the\nUnited States.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#USPNF\">[United States Pharmacopeia - National Formulary]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_preparation\">3.4. herbal preparation</h3>\n<div class=\"paragraph\">\n<p>preparation obtained by subjecting herbal substances to treatments such as\nextraction, distillation, expression, fractionation, purification,\nconcentration, or fermentation</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nHerbal preparations include, but are not limited to, comminuted or\npowdered herbal substances, tinctures, extracts, essential oils, expressed\njuices, and processed exudates.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#EP10th\">[European Pharmacopoeia 10th Edition]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_substance\">3.5. herbal substance</h3>\n<div class=\"paragraph\">\n<p>alt:[herbal drug]\nalt:[plant material]</p>\n</div>\n<div class=\"paragraph\">\n<p>whole, fragmented, or cut plants, parts of plants, algae, fungi, or lichen in\nan unprocessed state, usually in dried form but sometimes fresh</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCertain exudates that have not been subjected to a specific treatment are\nalso considered herbal substances.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#EP10th\">[European Pharmacopoeia 10th Edition]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_active_pharmaceutical_ingredient\">3.6. active pharmaceutical ingredient</h3>\n<div class=\"paragraph\">\n<p>alt:[API]\nalt:[active ingredient]</p>\n</div>\n<div class=\"paragraph\">\n<p>substance or mixture of substances intended to be used in the manufacture of a\ndrug product and that, when used in the production of a drug, becomes an active\ningredient in the drug product</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 1: In phytomedicine, the API may be a single compound or a defined\nmixture of compounds derived from the plant material.</p>\n</div>\n<div class=\"paragraph\">\n<p>NOTE 2: For some phytomedicines, the active constituents are not fully\ncharacterized, and the API is defined as the herbal preparation or its\nstandardized extract.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_marker_compound\">3.7. marker compound</h3>\n<div class=\"paragraph\">\n<p>chemical constituent or group of constituents characteristic of a particular\nplant species or plant part, used for identification, quality assessment, or\nstandardization purposes</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMarker compounds are not necessarily responsible for the therapeutic\nactivity of the phytomedicine.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_active_marker_compound\">3.8. active marker compound</h3>\n<div class=\"paragraph\">\n<p>marker compound that contributes to the therapeutic activity of a phytomedicine</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nActive markers may be used for standardization when the full mechanism\nof action is not understood.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_characteristic_constituent\">3.9. characteristic constituent</h3>\n<div class=\"paragraph\">\n<p>alt：【diagnostic marker】</p>\n</div>\n<div class=\"paragraph\">\n<p>chemical constituent that is unique to, or highly characteristic of, a\nparticular plant species and can be used for authentication purposes</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_standardized_extract\">3.10. standardized extract</h3>\n<div class=\"paragraph\">\n<p>herbal preparation that has been processed to contain a defined amount of one\nor more specified constituents, typically expressed as a percentage or range</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nStandardization may be based on active markers, analytical markers, or\ncharacteristic constituents.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quantified_extract\">3.11. quantified extract</h3>\n<div class=\"paragraph\">\n<p>herbal preparation with defined content ranges for one or more groups of\nconstituents</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nUnlike standardized extracts, quantified extracts specify acceptable\nranges rather than target values.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_native_extract\">3.12. native extract</h3>\n<div class=\"paragraph\">\n<p>alt:[genuine extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>extract that contains only constituents naturally present in the source\nmaterial, without added excipients or further processing that would alter its\ncomposition</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_processed_extract\">3.13. processed extract</h3>\n<div class=\"paragraph\">\n<p>extract that has undergone additional processing steps beyond initial\nextraction, which may include purification, concentration, drying, or addition\nof excipients</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction\">3.14. extraction</h3>\n<div class=\"paragraph\">\n<p>process of separating active or desirable constituents from plant material using\na solvent or other physical or chemical means</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_solvent\">3.15. extraction solvent</h3>\n<div class=\"paragraph\">\n<p>solvent used to extract desired constituents from plant material</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon extraction solvents include water, ethanol, methanol,\nsupercritical carbon dioxide, and various oils.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_yield\">3.16. extraction yield</h3>\n<div class=\"paragraph\">\n<p>alt:[extract yield]</p>\n</div>\n<div class=\"paragraph\">\n<p>amount of extract obtained from a specified amount of starting plant material,\ntypically expressed as a percentage by mass</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_phytochemistry\">3.17. phytochemistry</h3>\n<div class=\"paragraph\">\n<p>branch of chemistry dealing with the chemical constituents of plants and their\nproperties, reactions, and methods of isolation and identification</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacognosy\">3.18. pharmacognosy</h3>\n<div class=\"paragraph\">\n<p>study of medicines derived from natural sources, including plants, animals,\nand microorganisms, encompassing their physical, chemical, biochemical, and\nbiological properties</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_plant_part\">3.19. plant part</h3>\n<div class=\"paragraph\">\n<p>alt:[plant organ]\nalt:[medicinal plant part]</p>\n</div>\n<div class=\"paragraph\">\n<p>specific organ or portion of a plant that is used for medicinal purposes</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nRoot, rhizome, bark, leaf, flower, fruit, seed, whole herb.\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_identification\">3.20. botanical identification</h3>\n<div class=\"paragraph\">\n<p>process of determining the identity of a plant material to species level,\nincluding verification of the plant part used</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_adulteration\">3.21. adulteration</h3>\n<div class=\"paragraph\">\n<p>intentional addition of non-authentic material or the substitution of authentic\nmaterial with inferior or harmful substances</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nAdulteration may involve addition of synthetic drugs, other plant\nspecies, or contaminants.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_contamination\">3.22. contamination</h3>\n<div class=\"paragraph\">\n<p>unintended presence of harmful or undesirable substances in plant material or\nherbal preparations</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nHeavy metals, pesticides, mycotoxins, microorganisms, foreign plant material.\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_control\">3.23. quality control</h3>\n<div class=\"paragraph\">\n<p>operational techniques and activities used to fulfill requirements for quality</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nIn phytomedicine, quality control typically includes identity testing,\npurity testing, potency assessment, and stability testing.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ISO9000\">clause 3.3.7</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_stability\">3.24. stability</h3>\n<div class=\"paragraph\">\n<p>capacity of a phytomedicine product to remain within established specifications\nfor identity, strength, quality, and purity throughout its shelf life</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_shelf_life\">3.25. shelf life</h3>\n<div class=\"paragraph\">\n<p>alt:[expiration dating period]</p>\n</div>\n<div class=\"paragraph\">\n<p>time period during which a phytomedicine product is expected to remain within\napproved shelf-life specifications, provided it is stored under the conditions\ndefined on the container label</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_good_agricultural_and_collection_practices\">3.26. good agricultural and collection practices</h3>\n<div class=\"paragraph\">\n<p>alt:[GACP]</p>\n</div>\n<div class=\"paragraph\">\n<p>practices addressing quality assurance and control in the production and\ncollection of medicinal plants</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nGACP covers cultivation, harvesting, post-harvest processing, storage,\nand transportation.\n</td>\n</tr>\n</table>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#WHOGMP\">[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</a></p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_voucher_specimen\">3.27. voucher specimen</h3>\n<div class=\"paragraph\">\n<p>preserved sample of plant material that serves as a permanent record of the\nsource material used in scientific studies or commercial production</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nVoucher specimens enable verification of botanical identity and are\ntypically deposited in recognized herbaria.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_botanical_reference_material\">3.28. botanical reference material</h3>\n<div class=\"paragraph\">\n<p>alt:[BRM]</p>\n</div>\n<div class=\"paragraph\">\n<p>well-characterized material used as a standard for comparison in identity\ntesting and quality control</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nBotanical reference materials may be whole plant material, plant parts,\nor processed extracts.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_therapeutic_indication\">3.29. therapeutic indication</h3>\n<div class=\"paragraph\">\n<p>medical condition or disease state for which a phytomedicine is intended to\nbe used</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_contraindication\">3.30. contraindication</h3>\n<div class=\"paragraph\">\n<p>condition or factor that serves as a reason to withhold a certain medical\ntreatment due to the harm that it would cause the patient</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traditional_use\">3.31. traditional use</h3>\n<div class=\"paragraph\">\n<p>use of a medicinal plant or phytomedicine based on accumulated knowledge and\nexperience over generations within a specific cultural context</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_well_established_use\">3.32. well-established use</h3>\n<div class=\"paragraph\">\n<p>use of a medicinal plant or phytomedicine that has been recognized for at\nleast 10 years within a specific jurisdiction with demonstrated safety and\nefficacy</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nWell-established use may be a basis for simplified regulatory approval\nin some jurisdictions.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_safety\">3.33. safety</h3>\n<div class=\"paragraph\">\n<p>absence of unacceptable risk of harm to human health under intended or\nforeseeable conditions of use</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_efficacy\">3.34. efficacy</h3>\n<div class=\"paragraph\">\n<p>ability of a phytomedicine to produce a beneficial effect under controlled\nconditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacovigilance\">3.35. pharmacovigilance</h3>\n<div class=\"paragraph\">\n<p>science and activities relating to the detection, assessment, understanding,\nand prevention of adverse effects or any other drug-related problems</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_herbal_drug_interaction\">3.36. herbal-drug interaction</h3>\n<div class=\"paragraph\">\n<p>alt:[herb-drug interaction]\nalt:[HD interaction]</p>\n</div>\n<div class=\"paragraph\">\n<p>modification of the effect of a drug when co-administered with a herbal\npreparation, or modification of the effect of a herbal preparation when\nco-administered with a drug</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nInteractions may result in increased or decreased drug effects,\nor new adverse reactions.\n</td>\n</tr>\n</table>\n</div>\n<table id=\"table-markers\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Marker compound classification</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 75%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Classification</th>\n<th class=\"tableblock halign-left valign-top\">Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Active marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that contributes to the therapeutic effect and is used for\n  standardization</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Analytical marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound used for identification and quantification purposes, not necessarily\n  therapeutically active</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Toxicity marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that indicates potential toxicity concerns</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Stability marker</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compound that degrades in a predictable manner and indicates product stability</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"vocabulary\">4. Additional vocabulary</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This clause provides additional vocabulary organized by domain.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_extraction_and_processing\">4.1. Extraction and processing</h3>\n<div class=\"sect3\">\n<h4 id=\"_maceration\">4.1.1. maceration</h4>\n<div class=\"paragraph\">\n<p>extraction process in which plant material is soaked in a solvent at room\ntemperature for an extended period</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_percolation\">4.1.2. percolation</h4>\n<div class=\"paragraph\">\n<p>extraction process in which solvent passes through a column or bed of plant\nmaterial, typically under gravity or low pressure</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_decoction\">4.1.3. decoction</h4>\n<div class=\"paragraph\">\n<p>extraction process involving boiling plant material in water</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nDecoction is traditionally used for hard plant materials such as roots,\nbark, and seeds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_infusion\">4.1.4. infusion</h4>\n<div class=\"paragraph\">\n<p>extraction process in which plant material is steeped in hot or cold water\nwithout boiling</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nInfusion is traditionally used for delicate plant materials such as\nleaves and flowers.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_tincture\">4.1.5. tincture</h4>\n<div class=\"paragraph\">\n<p>alt:[alcoholic extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation obtained by maceration or percolation of plant material in\na mixture of alcohol and water</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTinctures are typically prepared at defined drug-to-extract ratios.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_fluid_extract\">4.1.6. fluid extract</h4>\n<div class=\"paragraph\">\n<p>alt:[liquid extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation containing the active constituents of plant material,\ntypically more concentrated than a tincture</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_dry_extract\">4.1.7. dry extract</h4>\n<div class=\"paragraph\">\n<p>solid extract obtained by removal of the extraction solvent, typically through\nevaporation or freeze-drying</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_soft_extract\">4.1.8. soft extract</h4>\n<div class=\"paragraph\">\n<p>alt:[semi-solid extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>extract with a viscous or semi-solid consistency, typically containing\nresidual moisture or solvent</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_drug_to_extract_ratio\">4.1.9. drug-to-extract ratio</h4>\n<div class=\"paragraph\">\n<p>alt:[DER]</p>\n</div>\n<div class=\"paragraph\">\n<p>ratio of the mass of starting plant material to the mass of the resulting\nextract</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nA 10:1 drug-to-extract ratio indicates that 10 kg of plant material yields\n1 kg of extract.\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_and_testing\">4.2. Quality and testing</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_testing\">4.2.1. identity testing</h4>\n<div class=\"paragraph\">\n<p>analytical procedures performed to confirm that a material is what it purports\nto be</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nIdentity testing may include macroscopic examination, microscopic\nanalysis, chromatographic fingerprinting, and spectroscopic methods.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_purity_testing\">4.2.2. purity testing</h4>\n<div class=\"paragraph\">\n<p>analytical procedures performed to determine the presence and amount of\nimpurities or contaminants</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_potency\">4.2.3. potency</h4>\n<div class=\"paragraph\">\n<p>measure of the biological activity or strength of a phytomedicine, typically\nexpressed relative to a reference standard</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_fingerprint\">4.2.4. fingerprint</h4>\n<div class=\"paragraph\">\n<p>chromatographic or spectroscopic pattern that is characteristic of a particular\nplant material or extract</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nFingerprints are used for identity confirmation and quality comparison.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_specification\">4.2.5. specification</h4>\n<div class=\"paragraph\">\n<p>list of tests, references to analytical procedures, and appropriate acceptance\ncriteria for a material</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ICHQ3r8\">[ICHQ3r8]</a></p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_dosage_forms\">4.3. Dosage forms</h3>\n<div class=\"sect3\">\n<h4 id=\"_oral_liquid\">4.3.1. oral liquid</h4>\n<div class=\"paragraph\">\n<p>alt:[liquid for oral use]</p>\n</div>\n<div class=\"paragraph\">\n<p>liquid preparation intended for oral administration</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_tablet\">4.3.2. tablet</h4>\n<div class=\"paragraph\">\n<p>solid dosage form containing phytomedicine ingredients, usually prepared by\ncompression</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_capsule\">4.3.3. capsule</h4>\n<div class=\"paragraph\">\n<p>solid dosage form in which the phytomedicine ingredient is enclosed in a\nsoluble container, typically made of gelatin or plant-derived materials</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_topical_preparation\">4.3.4. topical preparation</h4>\n<div class=\"paragraph\">\n<p>alt:[preparation for dermal use]</p>\n</div>\n<div class=\"paragraph\">\n<p>preparation intended for application to the skin or mucous membranes</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_powdered_extract\">4.3.5. powdered extract</h4>\n<div class=\"paragraph\">\n<p>alt:[spray-dried extract]</p>\n</div>\n<div class=\"paragraph\">\n<p>dry extract in powder form, typically produced by spray drying</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_biological_and_cultivation\">4.4. Biological and cultivation</h3>\n<div class=\"sect3\">\n<h4 id=\"_cultivation\">4.4.1. cultivation</h4>\n<div class=\"paragraph\">\n<p>practice of growing medicinal plants under controlled or semi-controlled\nconditions</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_wild_collection\">4.4.2. wild collection</h4>\n<div class=\"paragraph\">\n<p>alt:[wild harvesting]\nalt:[wild crafting]</p>\n</div>\n<div class=\"paragraph\">\n<p>gathering of medicinal plants from their natural habitat</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nWild collection requires sustainable practices to ensure species\nconservation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_sustainable_harvesting\">4.4.3. sustainable harvesting</h4>\n<div class=\"paragraph\">\n<p>collection of plant material in a manner that ensures the long-term survival\nof the species and its ecosystem</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSustainable harvesting considers regeneration rates, ecological impact,\nand biodiversity conservation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_good_agricultural_practices\">4.4.4. Good Agricultural Practices</h4>\n<div class=\"paragraph\">\n<p>alt:[GAP]</p>\n</div>\n<div class=\"paragraph\">\n<p>standards and practices for the production of medicinal plants under\ncontrolled agricultural conditions</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nGAP covers site selection, propagation, cultivation, plant protection,\nharvesting, and primary processing.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_regulatory_and_classification\">4.5. Regulatory and classification</h3>\n<div class=\"sect3\">\n<h4 id=\"_dietary_supplement\">4.5.1. dietary supplement</h4>\n<div class=\"paragraph\">\n<p>product intended to supplement the diet that contains one or more dietary\ningredients, including vitamins, minerals, herbs, or other botanicals</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nRegulatory classification of phytomedicines as dietary supplements varies\nby jurisdiction.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_traditional_herbal_medicinal_product\">4.5.2. traditional herbal medicinal product</h4>\n<div class=\"paragraph\">\n<p>alt:[THMP]</p>\n</div>\n<div class=\"paragraph\">\n<p>medicinal product whose active ingredients are exclusively herbal substances\nor herbal preparations, intended and designed for use without the supervision\nof a medical practitioner</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTraditional use of at least 30 years, including 15 years within the\nrelevant jurisdiction, is typically required for THMP status.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_health_claim\">4.5.3. health claim</h4>\n<div class=\"paragraph\">\n<p>statement that describes the relationship between a food or food component\nand a disease or health-related condition</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_structure_function_claim\">4.5.4. structure-function claim</h4>\n<div class=\"paragraph\">\n<p>statement that describes the role of a nutrient or dietary ingredient intended\nto affect the normal structure or function of the human body</p>\n</div>\n<table id=\"table-preparations\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Common herbal preparations and their characteristics</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 25%;\">\n<col style=\"width: 50%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Preparation type</th>\n<th class=\"tableblock halign-left valign-top\">Solvent/Method</th>\n<th class=\"tableblock halign-left valign-top\">Characteristics</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Tincture</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Alcohol/water mixture, maceration</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Liquid, typically 1:5 to 1:10 DER</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fluid extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Alcohol/water mixture, percolation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Liquid, typically 1:1 DER</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Dry extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Various solvents, evaporation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Solid powder, high concentration</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Soft extract</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Various solvents, partial evaporation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Viscous, contains residual solvent</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Essential oil</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Steam distillation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Volatile, aromatic liquid</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Expressed juice</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Mechanical pressing</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fresh plant liquid</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ISO3696\"></a>[ISO 3696:1987], Water for analytical laboratory use&#8201;&#8212;&#8201;Specification\nand test methods</p>\n</li>\n<li>\n<p><a id=\"ISO5725-1\"></a>[ISO 5725-1:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 1: General principles and definitions</p>\n</li>\n<li>\n<p><a id=\"ISO5725-2\"></a>[ISO 5725-2:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 2: Basic method for the determination\nof repeatability and reproducibility of a standard measurement method</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials], World\nHealth Organization, Geneva, 1998</p>\n</li>\n<li>\n<p><a id=\"WHOPHARM\"></a>[WHO Monographs on Selected Medicinal Plants], World Health\nOrganization, Geneva, Vols. 1-4</p>\n</li>\n<li>\n<p><a id=\"ESCP\"></a>[European Scientific Cooperative on Phytotherapy (ESCOP) Monographs],\nESCOP, Exeter, UK</p>\n</li>\n<li>\n<p>[<a id=\"BMABlumenthal\"></a>, <em>The ABC Clinical Guide to Herbs</em>.\nAmerican Botanical Council, Austin, TX, 2003</p>\n</li>\n<li>\n<p>[<a id=\"Bruneton\"></a>, <em>Pharmacognosy, Phytochemistry, Medicinal Plants</em>.\n2nd ed. Lavoisier Publishing, Paris, 1999</p>\n</li>\n<li>\n<p>[<a id=\"Evans\"></a>, <em>Trease and Evans' Pharmacognosy</em>. 15th ed.\nSaunders, Edinburgh, 2002</p>\n</li>\n<li>\n<p>[<a id=\"Heinrich\"></a>, <em>Fundamentals of Pharmacognosy and Phytotherapy</em>.\n2nd ed. Churchill Livingstone, Edinburgh, 2012</p>\n</li>\n<li>\n<p>[<a id=\"VanBreemen\"></a>, Developing standards for validating\nbotanical dietary supplements. <em>J. AOAC Int.</em> 2006, <strong>89</strong> (1) pp. 1-4</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_phytomedicine",
+          "title": "phytomedicine",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_medicinal_plant",
+          "title": "medicinal plant",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_drug_product",
+          "title": "botanical drug product",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_preparation",
+          "title": "herbal preparation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_substance",
+          "title": "herbal substance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_active_pharmaceutical_ingredient",
+          "title": "active pharmaceutical ingredient",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_marker_compound",
+          "title": "marker compound",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_active_marker_compound",
+          "title": "active marker compound",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_characteristic_constituent",
+          "title": "characteristic constituent",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_standardized_extract",
+          "title": "standardized extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_quantified_extract",
+          "title": "quantified extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_native_extract",
+          "title": "native extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_processed_extract",
+          "title": "processed extract",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction",
+          "title": "extraction",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction_solvent",
+          "title": "extraction solvent",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_extraction_yield",
+          "title": "extraction yield",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_phytochemistry",
+          "title": "phytochemistry",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacognosy",
+          "title": "pharmacognosy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_plant_part",
+          "title": "plant part",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_identification",
+          "title": "botanical identification",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_adulteration",
+          "title": "adulteration",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_contamination",
+          "title": "contamination",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_quality_control",
+          "title": "quality control",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_stability",
+          "title": "stability",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_shelf_life",
+          "title": "shelf life",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_good_agricultural_and_collection_practices",
+          "title": "good agricultural and collection practices",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_voucher_specimen",
+          "title": "voucher specimen",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_botanical_reference_material",
+          "title": "botanical reference material",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_therapeutic_indication",
+          "title": "therapeutic indication",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_contraindication",
+          "title": "contraindication",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traditional_use",
+          "title": "traditional use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_well_established_use",
+          "title": "well-established use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_safety",
+          "title": "safety",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_efficacy",
+          "title": "efficacy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacovigilance",
+          "title": "pharmacovigilance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_herbal_drug_interaction",
+          "title": "herbal-drug interaction",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "vocabulary",
+      "title": "Additional vocabulary",
+      "level": 1,
+      "children": [
+        {
+          "id": "_extraction_and_processing",
+          "title": "Extraction and processing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_maceration",
+              "title": "maceration",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_percolation",
+              "title": "percolation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_decoction",
+              "title": "decoction",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_infusion",
+              "title": "infusion",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_tincture",
+              "title": "tincture",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_fluid_extract",
+              "title": "fluid extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_dry_extract",
+              "title": "dry extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_soft_extract",
+              "title": "soft extract",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_drug_to_extract_ratio",
+              "title": "drug-to-extract ratio",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_quality_and_testing",
+          "title": "Quality and testing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_testing",
+              "title": "identity testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_purity_testing",
+              "title": "purity testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_potency",
+              "title": "potency",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_fingerprint",
+              "title": "fingerprint",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_specification",
+              "title": "specification",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_dosage_forms",
+          "title": "Dosage forms",
+          "level": 2,
+          "children": [
+            {
+              "id": "_oral_liquid",
+              "title": "oral liquid",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_tablet",
+              "title": "tablet",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_capsule",
+              "title": "capsule",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_topical_preparation",
+              "title": "topical preparation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_powdered_extract",
+              "title": "powdered extract",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_biological_and_cultivation",
+          "title": "Biological and cultivation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_cultivation",
+              "title": "cultivation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_wild_collection",
+              "title": "wild collection",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_sustainable_harvesting",
+              "title": "sustainable harvesting",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_good_agricultural_practices",
+              "title": "Good Agricultural Practices",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_regulatory_and_classification",
+          "title": "Regulatory and classification",
+          "level": 2,
+          "children": [
+            {
+              "id": "_dietary_supplement",
+              "title": "dietary supplement",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_traditional_herbal_medicinal_product",
+              "title": "traditional herbal medicinal product",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_health_claim",
+              "title": "health claim",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_structure_function_claim",
+              "title": "structure-function claim",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Terminology for Phytomedicine\n:docnumber: 0001\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Terminology for Phytomedicine\n:title-part-en: General vocabulary\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 1\n:technical-committee: Terminology and Nomenclature\n:library-ics: 01.040.11;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-vocabulary.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/src/content/standards/SIPM-0002.json
+++ b/src/content/standards/SIPM-0002.json
@@ -1,0 +1,279 @@
+{
+  "id": "SIPM-0002",
+  "title": "Medicinal Fungi Taxonomy",
+  "attributes": {
+    "docnumber": "0002",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Medicinal Fungi Taxonomy and Nomenclature",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Fungi and Lichens",
+    "library-ics": "07.100.20;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_medicinal_fungus\">3.1. medicinal fungus</a></li>\n<li><a href=\"#_basidiomycete\">3.2. basidiomycete</a></li>\n<li><a href=\"#_ascomycete\">3.3. ascomycete</a></li>\n<li><a href=\"#_fruiting_body\">3.4. fruiting body</a></li>\n<li><a href=\"#_mycelium\">3.5. mycelium</a></li>\n<li><a href=\"#_sclerotium\">3.6. sclerotium</a></li>\n<li><a href=\"#_spore\">3.7. spore</a></li>\n<li><a href=\"#_anamorph\">3.8. anamorph</a></li>\n<li><a href=\"#_teleomorph\">3.9. teleomorph</a></li>\n<li><a href=\"#_holomorph\">3.10. holomorph</a></li>\n<li><a href=\"#_species_complex\">3.11. species complex</a></li>\n<li><a href=\"#_strain\">3.12. strain</a></li>\n</ul>\n</li>\n<li><a href=\"#taxonomy\">4. Taxonomic classification</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_general_requirements\">4.1. General requirements</a></li>\n<li><a href=\"#_taxonomic_hierarchy\">4.2. Taxonomic hierarchy</a></li>\n<li><a href=\"#_scientific_names\">4.3. Scientific names</a></li>\n<li><a href=\"#_synonyms_and_deprecated_names\">4.4. Synonyms and deprecated names</a></li>\n</ul>\n</li>\n<li><a href=\"#nomenclature\">5. Nomenclature standards</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_general_requirements_2\">5.1. General requirements</a></li>\n<li><a href=\"#_documentation_requirements\">5.2. Documentation requirements</a></li>\n<li><a href=\"#_product_labeling\">5.3. Product labeling</a></li>\n<li><a href=\"#_quality_control_documentation\">5.4. Quality control documentation</a></li>\n<li><a href=\"#_species_specific_requirements\">5.5. Species-specific requirements</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 2,\n<em>Fungi and Lichens</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0002.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0002 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>Medicinal fungi have been used for therapeutic purposes across cultures for\nmillennia. In recent decades, scientific research has validated many traditional\nuses and identified bioactive compounds with significant pharmacological\nproperties. As the medicinal fungi industry grows, accurate taxonomy and\nstandardized nomenclature become essential for quality control, safety, and\nregulatory compliance.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes standards for the taxonomic classification and\nnomenclature of medicinal fungi used in phytomedicine and natural health\nproducts. It addresses the unique challenges of fungal taxonomy, including\nthe distinction between anamorph and teleomorph states, the complexity of\nfungal species complexes, and the need for consistent naming across scientific,\ncommercial, and regulatory contexts.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standards presented here are designed to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Ensure accurate identification of medicinal fungi species</p>\n</li>\n<li>\n<p>Promote consistent nomenclature in scientific and commercial contexts</p>\n</li>\n<li>\n<p>Facilitate communication between researchers, manufacturers, and regulators</p>\n</li>\n<li>\n<p>Support quality control and traceability throughout the supply chain</p>\n</li>\n<li>\n<p>Contribute to the conservation of medicinal fungi biodiversity</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to be used in conjunction with SIPM-0001 (Terminology\nfor Phytomedicine) and relevant analytical standards in the SIPM-0300 series.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the taxonomic classification and\nnomenclature of medicinal fungi used in phytomedicine and natural health\nproducts.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Scientific research and publication involving medicinal fungi</p>\n</li>\n<li>\n<p>Cultivation, collection, and trade of medicinal fungi raw materials</p>\n</li>\n<li>\n<p>Manufacturing and quality control of medicinal fungi products</p>\n</li>\n<li>\n<p>Regulatory submissions and compliance</p>\n</li>\n<li>\n<p>Education and training in mycology and phytomedicine</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Basidiomycetes (mushrooms, bracket fungi)</p>\n</li>\n<li>\n<p>Ascomycetes (morels, truffles, Cordyceps)</p>\n</li>\n<li>\n<p>Other fungi used for therapeutic purposes</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Detailed cultivation methods (addressed in SIPM-0200 series)</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Clinical protocols (addressed in SIPM-0400 series)</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICN\"></a>[International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code)]</p>\n</li>\n<li>\n<p><a id=\"ICNP\"></a>[International Code of Nomenclature of Prokaryotes]</p>\n</li>\n<li>\n<p><a id=\"IndexFungorum\"></a>[Index Fungorum Database]</p>\n</li>\n<li>\n<p><a id=\"MycoBank\"></a>[MycoBank Fungal Database]</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials]</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_medicinal_fungus\">3.1. medicinal fungus</h3>\n<div class=\"paragraph\">\n<p>alt:[medicinal mushroom]</p>\n</div>\n<div class=\"paragraph\">\n<p>fungal species that contains substances which can be used for therapeutic\npurposes or which are precursors for the synthesis of useful drugs</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_basidiomycete\">3.2. basidiomycete</h3>\n<div class=\"paragraph\">\n<p>member of the phylum Basidiomycota, characterized by the production of\nspores on a basidium</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon medicinal basidiomycetes include Reishi (Ganoderma lucidum),\nShiitake (Lentinula edodes), and Turkey Tail (Trametes versicolor).\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_ascomycete\">3.3. ascomycete</h3>\n<div class=\"paragraph\">\n<p>member of the phylum Ascomycota, characterized by the production of spores\nin an ascus</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCommon medicinal ascomycetes include Cordyceps (Cordyceps sinensis),\nMorel (Morchella spp.), and Chaga (Inonotus obliquus).\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_fruiting_body\">3.4. fruiting body</h3>\n<div class=\"paragraph\">\n<p>alt:[sporocarp]\nalt:[mushroom]</p>\n</div>\n<div class=\"paragraph\">\n<p>reproductive structure of a fungus that produces and disperses spores</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_mycelium\">3.5. mycelium</h3>\n<div class=\"paragraph\">\n<p>vegetative part of a fungus, consisting of a network of fine white filaments\n(hyphae)</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_sclerotium\">3.6. sclerotium</h3>\n<div class=\"paragraph\">\n<p>compact mass of hardened fungal mycelium containing food reserves, capable of\nremaining dormant for extended periods</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nThe sclerotium of Poria cocos (Fu Ling) is used medicinally.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_spore\">3.7. spore</h3>\n<div class=\"paragraph\">\n<p>reproductive unit of a fungus, capable of developing into a new organism</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_anamorph\">3.8. anamorph</h3>\n<div class=\"paragraph\">\n<p>asexual reproductive state of a fungus</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSome medicinal fungi are primarily known by their anamorph names.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_teleomorph\">3.9. teleomorph</h3>\n<div class=\"paragraph\">\n<p>sexual reproductive state of a fungus</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_holomorph\">3.10. holomorph</h3>\n<div class=\"paragraph\">\n<p>complete fungus including both anamorph and teleomorph states</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_species_complex\">3.11. species complex</h3>\n<div class=\"paragraph\">\n<p>group of closely related species that are difficult to distinguish morphologically</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSpecies complexes are common in medicinal fungi and may have different\nbioactive profiles.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_strain\">3.12. strain</h3>\n<div class=\"paragraph\">\n<p>genetically distinct isolate or subpopulation within a fungal species</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nDifferent strains of the same species may vary in their production of\nbioactive compounds.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"taxonomy\">4. Taxonomic classification</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"_general_requirements\">4.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>The taxonomic classification of medicinal fungi shall follow the International\nCode of Nomenclature for algae, fungi, and plants (ICN).</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_taxonomic_hierarchy\">4.2. Taxonomic hierarchy</h3>\n<div class=\"paragraph\">\n<p>Medicinal fungi shall be classified according to the following taxonomic\nhierarchy:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Kingdom</p>\n</li>\n<li>\n<p>Phylum</p>\n</li>\n<li>\n<p>Class</p>\n</li>\n<li>\n<p>Order</p>\n</li>\n<li>\n<p>Family</p>\n</li>\n<li>\n<p>Genus</p>\n</li>\n<li>\n<p>Species</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_scientific_names\">4.3. Scientific names</h3>\n<div class=\"sect3\">\n<h4 id=\"_latin_binomial\">4.3.1. Latin binomial</h4>\n<div class=\"paragraph\">\n<p>The scientific name of a medicinal fungus shall be expressed as a Latin\nbinomial consisting of genus name (capitalized) and species epithet\n(lowercase).</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum, Cordyceps sinensis, Lentinula edodes\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_author_citation\">4.3.2. Author citation</h4>\n<div class=\"paragraph\">\n<p>When first mention of a species is made in a document, the author citation\nshall be included.</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum (Curtis) P. Karst.\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_taxonomic_authorities\">4.3.3. Taxonomic authorities</h4>\n<div class=\"paragraph\">\n<p>Taxonomic nomenclature shall be verified against recognized databases:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Index Fungorum</p>\n</li>\n<li>\n<p>MycoBank</p>\n</li>\n<li>\n<p>GBIF (Global Biodiversity Information Facility)</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_synonyms_and_deprecated_names\">4.4. Synonyms and deprecated names</h3>\n<div class=\"sect3\">\n<h4 id=\"_synonym_handling\">4.4.1. Synonym handling</h4>\n<div class=\"paragraph\">\n<p>When a species has known synonyms, the currently accepted name shall be used\nas the primary identifier. Common synonyms may be listed for reference.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_deprecated_names\">4.4.2. Deprecated names</h4>\n<div class=\"paragraph\">\n<p>Names that have been taxonomically rejected or superseded shall be marked as\ndeprecated and shall not be used as primary identifiers.</p>\n</div>\n<table id=\"table-common-fungi\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Common medicinal fungi: accepted names and synonyms</caption>\n<colgroup>\n<col style=\"width: 40%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 30%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Accepted name</th>\n<th class=\"tableblock halign-left valign-top\">Common synonyms</th>\n<th class=\"tableblock halign-left valign-top\">Common name</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Ganoderma lucidum</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">G. lucidum sensu stricto</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Reishi, Lingzhi</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lentinula edodes</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lentinus edodes</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Shiitake</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Trametes versicolor</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Coriolus versicolor, Polyporus versicolor</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Turkey Tail, Yun Zhi</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cordyceps sinensis</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Ophiocordyceps sinensis</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Caterpillar fungus, Yartsa Gunbu</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Inonotus obliquus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Fuscoporia obliqua</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Chaga</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hericium erinaceus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hydnum erinaceus</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Lion&#8217;s Mane, Yamabushitake</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"nomenclature\">5. Nomenclature standards</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"_general_requirements_2\">5.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>This clause establishes standards for the use of nomenclature in scientific\npublications, product labels, and regulatory documents.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_documentation_requirements\">5.2. Documentation requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_required_elements\">5.2.1. Required elements</h4>\n<div class=\"paragraph\">\n<p>The following elements shall be included in all references to medicinal fungi:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Scientific name (genus and species)\nb) Authority citation (on first mention)\nc) Part of fungus used (fruiting body, mycelium, sclerotium, etc.)\nd) Source (wild-collected or cultivated)</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_recommended_elements\">5.2.2. Recommended elements</h4>\n<div class=\"paragraph\">\n<p>The following elements are recommended for comprehensive documentation:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Strain identifier (if applicable)</p>\n</li>\n<li>\n<p>Geographic origin</p>\n</li>\n<li>\n<p>Cultivation method</p>\n</li>\n<li>\n<p>Harvest date</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_product_labeling\">5.3. Product labeling</h3>\n<div class=\"sect3\">\n<h4 id=\"_standard_format\">5.3.1. Standard format</h4>\n<div class=\"paragraph\">\n<p>Product labels shall include the scientific name of the fungal ingredient.</p>\n</div>\n<div class=\"exampleblock\">\n<div class=\"content\">\nGanoderma lucidum (Reishi) fruiting body extract\n</div>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_common_names\">5.3.2. Common names</h4>\n<div class=\"paragraph\">\n<p>Common names may be included alongside scientific names but shall not replace\nthem as the primary identifier.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_quality_control_documentation\">5.4. Quality control documentation</h3>\n<div class=\"sect3\">\n<h4 id=\"_voucher_specimens\">5.4.1. Voucher specimens</h4>\n<div class=\"paragraph\">\n<p>Voucher specimens shall be preserved for all medicinal fungi used in research\nor commercial production.</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nSee SIPM-0001 for requirements for voucher specimens.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_identification_records\">5.4.2. Identification records</h4>\n<div class=\"paragraph\">\n<p>Records shall be maintained documenting the taxonomic identification process,\nincluding:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Morphological characteristics observed</p>\n</li>\n<li>\n<p>Reference materials used for comparison</p>\n</li>\n<li>\n<p>Name and qualifications of the identifier</p>\n</li>\n<li>\n<p>Date of identification</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_species_specific_requirements\">5.5. Species-specific requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_ganoderma_species\">5.5.1. Ganoderma species</h4>\n<div class=\"paragraph\">\n<p>Due to taxonomic complexity within the Ganoderma genus, identification shall\ninclude:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Macroscopic characteristics of the fruiting body</p>\n</li>\n<li>\n<p>Microscopic characteristics of spores and hyphae</p>\n</li>\n<li>\n<p>Geographic origin information</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_cordyceps_species\">5.5.2. Cordyceps species</h4>\n<div class=\"paragraph\">\n<p>Cordyceps products shall specify:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Species identity (C. sinensis, C. militaris, or other)</p>\n</li>\n<li>\n<p>Whether the product contains the natural complex (fungus + host) or\ncultured mycelium</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nC. sinensis is endangered in the wild; cultured alternatives are\ncommonly used.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[<a id=\"Kirk\"></a>, <em>Dictionary of the Fungi</em>. 10th ed. CABI Publishing,\nWallingford, UK, 2008</p>\n</li>\n<li>\n<p>[<a id=\"Stamets\"></a>, <em>Growing Gourmet and Medicinal Mushrooms</em>.\n3rd ed. Ten Speed Press, Berkeley, CA, 2000</p>\n</li>\n<li>\n<p>[<a id=\"Wasser\"></a>, Medicinal mushrooms as a source of antitumor and\nimmunomodulating polysaccharides. <em>Appl. Microbiol. Biotechnol.</em> 2002,\n<strong>60</strong> pp. 258-274</p>\n</li>\n<li>\n<p>[<a id=\"Hobbs\"></a>, <em>Medicinal Mushrooms: An Exploration of Tradition,\nHealing, and Culture</em>. Botanica Press, Santa Cruz, CA, 1995</p>\n</li>\n<li>\n<p>[<a id=\"Chang\"></a>, <em>Mushroom Biology and Mushroom Products</em>.\nChinese University Press, Hong Kong, 1993</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_medicinal_fungus",
+          "title": "medicinal fungus",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_basidiomycete",
+          "title": "basidiomycete",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_ascomycete",
+          "title": "ascomycete",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_fruiting_body",
+          "title": "fruiting body",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_mycelium",
+          "title": "mycelium",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_sclerotium",
+          "title": "sclerotium",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_spore",
+          "title": "spore",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_anamorph",
+          "title": "anamorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_teleomorph",
+          "title": "teleomorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_holomorph",
+          "title": "holomorph",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_species_complex",
+          "title": "species complex",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_strain",
+          "title": "strain",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "taxonomy",
+      "title": "Taxonomic classification",
+      "level": 1,
+      "children": [
+        {
+          "id": "_general_requirements",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_taxonomic_hierarchy",
+          "title": "Taxonomic hierarchy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_scientific_names",
+          "title": "Scientific names",
+          "level": 2,
+          "children": [
+            {
+              "id": "_latin_binomial",
+              "title": "Latin binomial",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_author_citation",
+              "title": "Author citation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_taxonomic_authorities",
+              "title": "Taxonomic authorities",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_synonyms_and_deprecated_names",
+          "title": "Synonyms and deprecated names",
+          "level": 2,
+          "children": [
+            {
+              "id": "_synonym_handling",
+              "title": "Synonym handling",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_deprecated_names",
+              "title": "Deprecated names",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nomenclature",
+      "title": "Nomenclature standards",
+      "level": 1,
+      "children": [
+        {
+          "id": "_general_requirements_2",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_documentation_requirements",
+          "title": "Documentation requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_required_elements",
+              "title": "Required elements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_recommended_elements",
+              "title": "Recommended elements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_product_labeling",
+          "title": "Product labeling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_standard_format",
+              "title": "Standard format",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_common_names",
+              "title": "Common names",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_quality_control_documentation",
+          "title": "Quality control documentation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_voucher_specimens",
+              "title": "Voucher specimens",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_identification_records",
+              "title": "Identification records",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "_species_specific_requirements",
+          "title": "Species-specific requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_ganoderma_species",
+              "title": "Ganoderma species",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_cordyceps_species",
+              "title": "Cordyceps species",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Medicinal Fungi Taxonomy\n:docnumber: 0002\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Medicinal Fungi Taxonomy and Nomenclature\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 2\n:technical-committee: Fungi and Lichens\n:library-ics: 07.100.20;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-taxonomy.adoc[]\n\ninclude::sections/05-nomenclature.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/src/content/standards/SIPM-0200.json
+++ b/src/content/standards/SIPM-0200.json
@@ -1,0 +1,377 @@
+{
+  "id": "SIPM-0200",
+  "title": "Agricultural Practices for Medicinal Plants",
+  "attributes": {
+    "docnumber": "0200",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Agricultural Practices for Medicinal Plants",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Agricultural Practices",
+    "library-ics": "65.020.20;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_cultivation_site\">3.1. cultivation site</a></li>\n<li><a href=\"#_seed_stock\">3.2. seed stock</a></li>\n<li><a href=\"#_cultivation_protocol\">3.3. cultivation protocol</a></li>\n<li><a href=\"#_plant_protection\">3.4. plant protection</a></li>\n<li><a href=\"#_primary_processing\">3.5. primary processing</a></li>\n<li><a href=\"#_batch\">3.6. batch</a></li>\n<li><a href=\"#_traceability\">3.7. traceability</a></li>\n</ul>\n</li>\n<li><a href=\"#site-selection\">4. Site selection and preparation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-site-criteria\">4.1. Site selection criteria</a></li>\n<li><a href=\"#sec-site-records\">4.2. Site documentation</a></li>\n<li><a href=\"#_soil_management\">4.3. Soil management</a></li>\n</ul>\n</li>\n<li><a href=\"#propagation\">5. Propagation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-seed-stock\">5.1. Seed stock requirements</a></li>\n<li><a href=\"#sec-propagation-methods\">5.2. Propagation methods</a></li>\n<li><a href=\"#sec-nursery\">5.3. Nursery management</a></li>\n</ul>\n</li>\n<li><a href=\"#cultivation\">6. Cultivation management</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-planting\">6.1. Planting and establishment</a></li>\n<li><a href=\"#sec-irrigation\">6.2. Irrigation</a></li>\n<li><a href=\"#sec-plant-protection\">6.3. Plant protection</a></li>\n<li><a href=\"#sec-records\">6.4. Cultivation records</a></li>\n</ul>\n</li>\n<li><a href=\"#harvesting\">7. Harvesting</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-harvest-timing\">7.1. Harvest timing</a></li>\n<li><a href=\"#sec-harvest-methods\">7.2. Harvest methods</a></li>\n<li><a href=\"#sec-field-handling\">7.3. Field handling</a></li>\n</ul>\n</li>\n<li><a href=\"#postharvest\">8. Post-harvest processing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-primary-processing\">8.1. Primary processing operations</a></li>\n<li><a href=\"#sec-packaging\">8.2. Packaging and labeling</a></li>\n<li><a href=\"#sec-storage\">8.3. Storage</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 3,\n<em>Agricultural Practices</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0200.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0200 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The quality of phytomedicine products begins with the quality of the raw plant\nmaterial. Agricultural practices directly influence the identity, purity,\npotency, and safety of medicinal plants and, consequently, the final products\nderived from them. This standard establishes requirements for the cultivation,\ncollection, and primary processing of medicinal plants to ensure consistent\nquality throughout the supply chain.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document is aligned with international guidelines, including the WHO\nGuidelines on Good Agricultural and Collection Practices (GACP) for Medicinal\nPlants, and incorporates additional requirements specific to the phytomedicine\nindustry.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses the complete agricultural production cycle:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Site selection and preparation</p>\n</li>\n<li>\n<p>Propagation and cultivation</p>\n</li>\n<li>\n<p>Plant protection and pest management</p>\n</li>\n<li>\n<p>Harvesting and primary processing</p>\n</li>\n<li>\n<p>Storage and transportation</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Implementation of this standard supports:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Traceability of medicinal plant materials</p>\n</li>\n<li>\n<p>Consistency of phytochemical profiles</p>\n</li>\n<li>\n<p>Minimization of contamination risks</p>\n</li>\n<li>\n<p>Environmental sustainability</p>\n</li>\n<li>\n<p>Social responsibility in medicinal plant production</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the agricultural cultivation and\nprimary processing of medicinal plants used in phytomedicine.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Cultivation of medicinal plants under controlled agricultural conditions</p>\n</li>\n<li>\n<p>Primary processing of plant materials after harvest</p>\n</li>\n<li>\n<p>Documentation and traceability throughout the production cycle</p>\n</li>\n<li>\n<p>Quality management systems for medicinal plant production</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Wild collection practices (addressed in SIPM-0201)</p>\n</li>\n<li>\n<p>Processing of plant materials into extracts or finished products</p>\n</li>\n<li>\n<p>Specific analytical methods (addressed in SIPM-0300 series)</p>\n</li>\n<li>\n<p>Fungal cultivation (addressed in SIPM-0202)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The requirements in this document are intended to be used by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Cultivators and farmers of medicinal plants</p>\n</li>\n<li>\n<p>Primary processors of medicinal plant materials</p>\n</li>\n<li>\n<p>Quality assurance personnel</p>\n</li>\n<li>\n<p>Regulatory bodies and certification organizations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"WHOGACP\"></a>[WHO Guidelines on Good Agricultural and Collection Practices (GACP) for Medicinal Plants]</p>\n</li>\n<li>\n<p><a id=\"ISO9001\"></a>[ISO 9001:2015], Quality management systems&#8201;&#8212;&#8201;Requirements</p>\n</li>\n<li>\n<p><a id=\"ISO14001\"></a>[ISO 14001:2015], Environmental management systems&#8201;&#8212;&#8201;Requirements\nwith guidance for use</p>\n</li>\n<li>\n<p><a id=\"GLOBALGAP\"></a>[GLOBALG.A.P. Integrated Farm Assurance Standard]</p>\n</li>\n<li>\n<p><a id=\"EUROPAM\"></a>[European Herb Growers Association (EUROPAM) Good Agricultural Practice Guidelines]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_cultivation_site\">3.1. cultivation site</h3>\n<div class=\"paragraph\">\n<p>area of land or controlled environment used for growing medicinal plants</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nCultivation sites may include open fields, greenhouses, hydroponic\nsystems, or other controlled environments.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_seed_stock\">3.2. seed stock</h3>\n<div class=\"paragraph\">\n<p>material used for propagation, including true seeds, cuttings, rhizomes,\nbulbs, or other vegetative propagation material</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_cultivation_protocol\">3.3. cultivation protocol</h3>\n<div class=\"paragraph\">\n<p>documented procedures for growing a specific medicinal plant species,\nincluding environmental parameters, inputs, and timing</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_plant_protection\">3.4. plant protection</h3>\n<div class=\"paragraph\">\n<p>measures taken to protect medicinal plants from pests, diseases, and other\nthreats to their health and quality</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_primary_processing\">3.5. primary processing</h3>\n<div class=\"paragraph\">\n<p>initial processing of plant material after harvest, including cleaning,\ndrying, cutting, and packaging</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nPrimary processing does not include extraction or formulation.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_batch\">3.6. batch</h3>\n<div class=\"paragraph\">\n<p>defined quantity of plant material produced in a single process or series of\nprocesses, allowing for traceability</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traceability\">3.7. traceability</h3>\n<div class=\"paragraph\">\n<p>ability to trace the history, application, or location of plant material\nthrough recorded identification data</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"site-selection\">4. Site selection and preparation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-site-criteria\">4.1. Site selection criteria</h3>\n<div class=\"sect3\">\n<h4 id=\"_environmental_requirements\">4.1.1. Environmental requirements</h4>\n<div class=\"paragraph\">\n<p>The cultivation site shall meet the environmental requirements of the target\nplant species, including:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Climate conditions (temperature, rainfall, sunlight)\nb) Soil characteristics (type, pH, drainage, nutrient content)\nc) Water availability and quality\nd) Altitude and topography</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_contamination_assessment\">4.1.2. Contamination assessment</h4>\n<div class=\"paragraph\">\n<p>Prior to establishment, the site shall be assessed for potential sources of\ncontamination, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Previous land use and potential residual contaminants</p>\n</li>\n<li>\n<p>Proximity to industrial facilities or major transportation routes</p>\n</li>\n<li>\n<p>Presence of heavy metals in soil and water</p>\n</li>\n<li>\n<p>Risk of pesticide drift from neighboring agricultural operations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-site-records\">4.2. Site documentation</h3>\n<div class=\"paragraph\">\n<p>The following documentation shall be maintained:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Site location and boundaries (geographic coordinates)</p>\n</li>\n<li>\n<p>History of land use for at least the previous 5 years</p>\n</li>\n<li>\n<p>Results of soil and water testing</p>\n</li>\n<li>\n<p>Map of the cultivation area</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_soil_management\">4.3. Soil management</h3>\n<div class=\"sect3\">\n<h4 id=\"_soil_testing\">4.3.1. Soil testing</h4>\n<div class=\"paragraph\">\n<p>Soil shall be tested prior to planting and periodically during cultivation for:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Nutrient content</p>\n</li>\n<li>\n<p>pH level</p>\n</li>\n<li>\n<p>Heavy metal content</p>\n</li>\n<li>\n<p>Organic matter content</p>\n</li>\n<li>\n<p>Presence of pathogens</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_soil_amendment\">4.3.2. Soil amendment</h4>\n<div class=\"paragraph\">\n<p>Soil amendments, including fertilizers and conditioners, shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Documented with product name, source, and application rate</p>\n</li>\n<li>\n<p>Applied according to label instructions or professional recommendations</p>\n</li>\n<li>\n<p>Sourced from suppliers who provide certificates of analysis</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"propagation\">5. Propagation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-seed-stock\">5.1. Seed stock requirements</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_verification\">5.1.1. Identity verification</h4>\n<div class=\"paragraph\">\n<p>The identity of seed stock shall be verified to species level before\npropagation. Acceptable methods include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Purchase from certified suppliers with documentation</p>\n</li>\n<li>\n<p>Comparison with reference materials</p>\n</li>\n<li>\n<p>DNA-based authentication (where applicable)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_quality_requirements\">5.1.2. Quality requirements</h4>\n<div class=\"paragraph\">\n<p>Seed stock shall be free from:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Visible signs of disease or pest damage</p>\n</li>\n<li>\n<p>Contamination with seeds of other species</p>\n</li>\n<li>\n<p>Physical damage or deterioration</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-propagation-methods\">5.2. Propagation methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_documentation\">5.2.1. Documentation</h4>\n<div class=\"paragraph\">\n<p>The propagation method used shall be documented, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Type of propagation material (seed, cutting, rhizome, etc.)</p>\n</li>\n<li>\n<p>Source of propagation material</p>\n</li>\n<li>\n<p>Date of propagation</p>\n</li>\n<li>\n<p>Environmental conditions</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_vegetative_propagation\">5.2.2. Vegetative propagation</h4>\n<div class=\"paragraph\">\n<p>For vegetatively propagated species:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Mother plants shall be positively identified and healthy</p>\n</li>\n<li>\n<p>Regular inspection for trueness-to-type shall be conducted</p>\n</li>\n<li>\n<p>Records of mother plant lineage shall be maintained</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-nursery\">5.3. Nursery management</h3>\n<div class=\"paragraph\">\n<p>Nursery operations shall be conducted in a manner that:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Prevents cross-contamination between species or batches</p>\n</li>\n<li>\n<p>Maintains appropriate environmental conditions</p>\n</li>\n<li>\n<p>Includes regular inspection for pests and diseases</p>\n</li>\n<li>\n<p>Documents all inputs and treatments applied</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"cultivation\">6. Cultivation management</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-planting\">6.1. Planting and establishment</h3>\n<div class=\"paragraph\">\n<p>Planting operations shall be documented, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Date of planting</p>\n</li>\n<li>\n<p>Plant spacing and density</p>\n</li>\n<li>\n<p>Number of plants or quantity of seed used</p>\n</li>\n<li>\n<p>Field or bed identification</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-irrigation\">6.2. Irrigation</h3>\n<div class=\"sect3\">\n<h4 id=\"_water_quality\">6.2.1. Water quality</h4>\n<div class=\"paragraph\">\n<p>Irrigation water shall meet quality standards appropriate for the intended\nuse, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Absence of pathogenic microorganisms</p>\n</li>\n<li>\n<p>Acceptable levels of chemical contaminants</p>\n</li>\n<li>\n<p>pH within appropriate range</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_irrigation_records\">6.2.2. Irrigation records</h4>\n<div class=\"paragraph\">\n<p>Irrigation records shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Source of water</p>\n</li>\n<li>\n<p>Method of application</p>\n</li>\n<li>\n<p>Frequency and duration</p>\n</li>\n<li>\n<p>Any treatments applied to water</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-plant-protection\">6.3. Plant protection</h3>\n<div class=\"sect3\">\n<h4 id=\"_integrated_pest_management\">6.3.1. Integrated pest management</h4>\n<div class=\"paragraph\">\n<p>Plant protection shall be based on integrated pest management (IPM) principles:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Prevention through good cultural practices</p>\n</li>\n<li>\n<p>Monitoring and early detection</p>\n</li>\n<li>\n<p>Use of biological controls where appropriate</p>\n</li>\n<li>\n<p>Chemical controls only when necessary and permitted</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_pesticide_use\">6.3.2. Pesticide use</h4>\n<div class=\"paragraph\">\n<p>When pesticides are used:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Only products approved for use on medicinal plants shall be applied</p>\n</li>\n<li>\n<p>Application shall follow label instructions</p>\n</li>\n<li>\n<p>Pre-harvest intervals shall be strictly observed</p>\n</li>\n<li>\n<p>All applications shall be documented</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMany jurisdictions have specific restrictions on pesticide use for\nmedicinal plants.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-records\">6.4. Cultivation records</h3>\n<div class=\"paragraph\">\n<p>Records shall be maintained throughout the cultivation period, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Planting dates and methods</p>\n</li>\n<li>\n<p>Environmental conditions (where controlled)</p>\n</li>\n<li>\n<p>Irrigation and fertilization</p>\n</li>\n<li>\n<p>Pest and disease observations and treatments</p>\n</li>\n<li>\n<p>Any deviation from standard protocols</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"harvesting\">7. Harvesting</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-harvest-timing\">7.1. Harvest timing</h3>\n<div class=\"sect3\">\n<h4 id=\"_optimal_harvest_time\">7.1.1. Optimal harvest time</h4>\n<div class=\"paragraph\">\n<p>Harvest timing shall be determined based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Phytochemical content of the target plant part</p>\n</li>\n<li>\n<p>Stage of plant development</p>\n</li>\n<li>\n<p>Time of day (for species where this affects quality)</p>\n</li>\n<li>\n<p>Environmental conditions</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_documentation_2\">7.1.2. Documentation</h4>\n<div class=\"paragraph\">\n<p>The rationale for harvest timing decisions shall be documented.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-harvest-methods\">7.2. Harvest methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_personnel_requirements\">7.2.1. Personnel requirements</h4>\n<div class=\"paragraph\">\n<p>Harvest personnel shall be trained in:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Correct plant part identification</p>\n</li>\n<li>\n<p>Harvesting techniques</p>\n</li>\n<li>\n<p>Hygiene requirements</p>\n</li>\n<li>\n<p>Recognition of contamination or quality issues</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_equipment\">7.2.2. Equipment</h4>\n<div class=\"paragraph\">\n<p>Harvest equipment shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clean and in good working condition</p>\n</li>\n<li>\n<p>Constructed of materials that do not contaminate plant material</p>\n</li>\n<li>\n<p>Regularly inspected and maintained</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-field-handling\">7.3. Field handling</h3>\n<div class=\"sect3\">\n<h4 id=\"_contamination_prevention\">7.3.1. Contamination prevention</h4>\n<div class=\"paragraph\">\n<p>Harvested material shall be protected from contamination during handling:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clean containers shall be used</p>\n</li>\n<li>\n<p>Contact with soil shall be minimized</p>\n</li>\n<li>\n<p>Material shall not be placed directly on the ground</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_temperature_management\">7.3.2. Temperature management</h4>\n<div class=\"paragraph\">\n<p>For temperature-sensitive materials:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Exposure to direct sunlight shall be minimized</p>\n</li>\n<li>\n<p>Material shall be transported to processing area promptly</p>\n</li>\n<li>\n<p>Temporary storage conditions shall be documented</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"postharvest\">8. Post-harvest processing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-primary-processing\">8.1. Primary processing operations</h3>\n<div class=\"sect3\">\n<h4 id=\"_cleaning\">8.1.1. Cleaning</h4>\n<div class=\"paragraph\">\n<p>Harvested material shall be cleaned to remove:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Soil and extraneous matter</p>\n</li>\n<li>\n<p>Damaged or diseased plant parts</p>\n</li>\n<li>\n<p>Non-target plant species</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_drying\">8.1.2. Drying</h4>\n<div class=\"paragraph\">\n<p>Drying operations shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Use appropriate temperature for the species</p>\n</li>\n<li>\n<p>Ensure adequate air circulation</p>\n</li>\n<li>\n<p>Achieve target moisture content for storage stability</p>\n</li>\n<li>\n<p>Be documented with temperature and duration records</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_cutting_and_size_reduction\">8.1.3. Cutting and size reduction</h4>\n<div class=\"paragraph\">\n<p>When cutting or size reduction is performed:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Equipment shall be clean and appropriate for the material</p>\n</li>\n<li>\n<p>Dust generation shall be controlled</p>\n</li>\n<li>\n<p>Material identity shall be maintained throughout</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-packaging\">8.2. Packaging and labeling</h3>\n<div class=\"sect3\">\n<h4 id=\"_container_requirements\">8.2.1. Container requirements</h4>\n<div class=\"paragraph\">\n<p>Primary packaging shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Protect material from contamination</p>\n</li>\n<li>\n<p>Preserve material quality during storage</p>\n</li>\n<li>\n<p>Be appropriate for the material characteristics</p>\n</li>\n<li>\n<p>Be traceable to batch and source</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_labeling_requirements\">8.2.2. Labeling requirements</h4>\n<div class=\"paragraph\">\n<p>Each container shall be labeled with at minimum:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Plant name (scientific name and common name)</p>\n</li>\n<li>\n<p>Plant part</p>\n</li>\n<li>\n<p>Batch number</p>\n</li>\n<li>\n<p>Date of processing</p>\n</li>\n<li>\n<p>Net weight</p>\n</li>\n<li>\n<p>Storage conditions</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-storage\">8.3. Storage</h3>\n<div class=\"paragraph\">\n<p>Storage conditions shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Appropriate for maintaining material quality</p>\n</li>\n<li>\n<p>Protected from pests and contamination</p>\n</li>\n<li>\n<p>Controlled for temperature and humidity where required</p>\n</li>\n<li>\n<p>Documented with monitoring records</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"FAOGAP\"></a>[FAO Good Agricultural Practices], Food and Agriculture Organization\nof the United Nations, Rome</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials], World\nHealth Organization, Geneva, 1998</p>\n</li>\n<li>\n<p><a id=\"AHPAGAP\"></a>[AHPA Good Agricultural Practices], American Herbal Products\nAssociation, Silver Spring, MD</p>\n</li>\n<li>\n<p>[<a id=\"Craker\"></a>, <em>Herbs, Botanicals and Teas</em>. Haworth Press,\nBinghamton, NY, 2000</p>\n</li>\n<li>\n<p>[<a id=\"Simon\"></a>, <em>Herbs: An Indexed Bibliography, 1971-1980</em>.\nElsevier, Amsterdam, 1984</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_cultivation_site",
+          "title": "cultivation site",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_seed_stock",
+          "title": "seed stock",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_cultivation_protocol",
+          "title": "cultivation protocol",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_plant_protection",
+          "title": "plant protection",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_primary_processing",
+          "title": "primary processing",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_batch",
+          "title": "batch",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traceability",
+          "title": "traceability",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "site-selection",
+      "title": "Site selection and preparation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-site-criteria",
+          "title": "Site selection criteria",
+          "level": 2,
+          "children": [
+            {
+              "id": "_environmental_requirements",
+              "title": "Environmental requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_contamination_assessment",
+              "title": "Contamination assessment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-site-records",
+          "title": "Site documentation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_soil_management",
+          "title": "Soil management",
+          "level": 2,
+          "children": [
+            {
+              "id": "_soil_testing",
+              "title": "Soil testing",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_soil_amendment",
+              "title": "Soil amendment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "propagation",
+      "title": "Propagation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-seed-stock",
+          "title": "Seed stock requirements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_verification",
+              "title": "Identity verification",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_quality_requirements",
+              "title": "Quality requirements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-propagation-methods",
+          "title": "Propagation methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_documentation",
+              "title": "Documentation",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_vegetative_propagation",
+              "title": "Vegetative propagation",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-nursery",
+          "title": "Nursery management",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "cultivation",
+      "title": "Cultivation management",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-planting",
+          "title": "Planting and establishment",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-irrigation",
+          "title": "Irrigation",
+          "level": 2,
+          "children": [
+            {
+              "id": "_water_quality",
+              "title": "Water quality",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_irrigation_records",
+              "title": "Irrigation records",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-plant-protection",
+          "title": "Plant protection",
+          "level": 2,
+          "children": [
+            {
+              "id": "_integrated_pest_management",
+              "title": "Integrated pest management",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_pesticide_use",
+              "title": "Pesticide use",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-records",
+          "title": "Cultivation records",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "harvesting",
+      "title": "Harvesting",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-harvest-timing",
+          "title": "Harvest timing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_optimal_harvest_time",
+              "title": "Optimal harvest time",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_documentation_2",
+              "title": "Documentation",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-harvest-methods",
+          "title": "Harvest methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_personnel_requirements",
+              "title": "Personnel requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_equipment",
+              "title": "Equipment",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-field-handling",
+          "title": "Field handling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_contamination_prevention",
+              "title": "Contamination prevention",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_temperature_management",
+              "title": "Temperature management",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "postharvest",
+      "title": "Post-harvest processing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-primary-processing",
+          "title": "Primary processing operations",
+          "level": 2,
+          "children": [
+            {
+              "id": "_cleaning",
+              "title": "Cleaning",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_drying",
+              "title": "Drying",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_cutting_and_size_reduction",
+              "title": "Cutting and size reduction",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-packaging",
+          "title": "Packaging and labeling",
+          "level": 2,
+          "children": [
+            {
+              "id": "_container_requirements",
+              "title": "Container requirements",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_labeling_requirements",
+              "title": "Labeling requirements",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-storage",
+          "title": "Storage",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Agricultural Practices for Medicinal Plants\n:docnumber: 0200\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Agricultural Practices for Medicinal Plants\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 3\n:technical-committee: Agricultural Practices\n:library-ics: 65.020.20;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-site-selection.adoc[]\n\ninclude::sections/05-propagation.adoc[]\n\ninclude::sections/06-cultivation.adoc[]\n\ninclude::sections/07-harvesting.adoc[]\n\ninclude::sections/08-postharvest.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/src/content/standards/SIPM-0300.json
+++ b/src/content/standards/SIPM-0300.json
@@ -1,0 +1,376 @@
+{
+  "id": "SIPM-0300",
+  "title": "Analytical Methods for Phytomedicine",
+  "attributes": {
+    "docnumber": "0300",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Analytical Methods for Phytomedicine",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Analytical Methods",
+    "library-ics": "07.100.01;11.120"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_analytical_procedure\">3.1. analytical procedure</a></li>\n<li><a href=\"#_method_validation\">3.2. method validation</a></li>\n<li><a href=\"#_specificity\">3.3. specificity</a></li>\n<li><a href=\"#_accuracy\">3.4. accuracy</a></li>\n<li><a href=\"#_precision\">3.5. precision</a></li>\n<li><a href=\"#_repeatability\">3.6. repeatability</a></li>\n<li><a href=\"#_intermediate_precision\">3.7. intermediate precision</a></li>\n<li><a href=\"#_reproducibility\">3.8. reproducibility</a></li>\n<li><a href=\"#_limit_of_detection\">3.9. limit of detection</a></li>\n<li><a href=\"#_limit_of_quantitation\">3.10. limit of quantitation</a></li>\n<li><a href=\"#_linearity\">3.11. linearity</a></li>\n<li><a href=\"#_range\">3.12. range</a></li>\n<li><a href=\"#_robustness\">3.13. robustness</a></li>\n<li><a href=\"#_reference_standard\">3.14. reference standard</a></li>\n<li><a href=\"#_system_suitability\">3.15. system suitability</a></li>\n</ul>\n</li>\n<li><a href=\"#identity\">4. Identity testing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-identity-general\">4.1. General requirements</a></li>\n<li><a href=\"#_methods_of_identity_testing\">4.2. Methods of identity testing</a></li>\n<li><a href=\"#sec-identity-acceptance\">4.3. Acceptance criteria</a></li>\n</ul>\n</li>\n<li><a href=\"#purity\">5. Purity testing</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-purity-general\">5.1. General requirements</a></li>\n<li><a href=\"#sec-contaminants\">5.2. Contaminant categories</a></li>\n</ul>\n</li>\n<li><a href=\"#potency\">6. Potency determination</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-potency-general\">6.1. General requirements</a></li>\n<li><a href=\"#sec-analyte-selection\">6.2. Analyte selection</a></li>\n<li><a href=\"#sec-methods\">6.3. Quantitative methods</a></li>\n<li><a href=\"#sec-specifications\">6.4. Specifications</a></li>\n</ul>\n</li>\n<li><a href=\"#validation\">7. Method validation</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-validation-requirements\">7.1. Validation requirements</a></li>\n<li><a href=\"#sec-validation-parameters\">7.2. Validation parameters</a></li>\n<li><a href=\"#sec-protocol\">7.3. Validation protocol</a></li>\n<li><a href=\"#sec-report\">7.4. Validation report</a></li>\n<li><a href=\"#sec-revalidation\">7.5. Revalidation</a></li>\n</ul>\n</li>\n<li><a href=\"#reporting\">8. Reporting of results</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-report-content\">8.1. Certificate of analysis</a></li>\n<li><a href=\"#sec-result-expression\">8.2. Expression of results</a></li>\n<li><a href=\"#sec-records\">8.3. Record retention</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 4,\n<em>Analytical Methods</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0300.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0300 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The quality and safety of phytomedicine products depend on reliable analytical\nmethods for identity verification, purity assessment, and potency determination.\nUnlike conventional pharmaceuticals, phytomedicines present unique analytical\nchallenges due to their complex chemical composition and natural variability.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document establishes general requirements for analytical methods used in\nthe quality control of phytomedicine products. It provides a framework for\nmethod selection, validation, and application that ensures reliable and\nreproducible results across laboratories and jurisdictions.</p>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses three fundamental aspects of phytomedicine analysis:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p><strong>Identity</strong>: Confirming that the material is what it purports to be</p>\n</li>\n<li>\n<p><strong>Purity</strong>: Ensuring the material is free from unacceptable contamination</p>\n</li>\n<li>\n<p><strong>Potency</strong>: Determining the concentration of active or marker constituents</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to be used in conjunction with specific analytical\nmethod standards in the SIPM-0300 series, which provide detailed procedures\nfor particular tests and analytes.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies general requirements for analytical methods used in\nthe quality control of phytomedicine products.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Identity testing of plant materials and extracts</p>\n</li>\n<li>\n<p>Purity testing for contaminants and impurities</p>\n</li>\n<li>\n<p>Potency determination for active or marker constituents</p>\n</li>\n<li>\n<p>Method validation and verification</p>\n</li>\n<li>\n<p>Documentation and reporting of analytical results</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Herbal substances and preparations</p>\n</li>\n<li>\n<p>Medicinal fungi materials and products</p>\n</li>\n<li>\n<p>Finished phytomedicine products</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Specific analytical procedures for individual compounds or matrices</p>\n</li>\n<li>\n<p>Microbiological testing methods</p>\n</li>\n<li>\n<p>Clinical laboratory methods</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICHQ2R2\"></a>[ICH Q2(R2) Validation of Analytical Procedures]</p>\n</li>\n<li>\n<p><a id=\"ISO17025\"></a>[ISO/IEC 17025:2017], General requirements for the competence of\ntesting and calibration laboratories</p>\n</li>\n<li>\n<p><a id=\"ISO5725-1\"></a>[ISO 5725-1:1994], Accuracy (trueness and precision) of\nmeasurement methods and results&#8201;&#8212;&#8201;Part 1: General principles and definitions</p>\n</li>\n<li>\n<p><a id=\"EP10th\"></a>[European Pharmacopoeia 10th Edition]</p>\n</li>\n<li>\n<p><a id=\"USPNF\"></a>[United States Pharmacopeia - National Formulary]</p>\n</li>\n<li>\n<p><a id=\"WHOQCM\"></a>[WHO Quality Control Methods for Medicinal Plant Materials]</p>\n</li>\n<li>\n<p><a id=\"ICHQ3R8\"></a>[ICH Q3(R8) Guideline for Elemental Impurities]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_analytical_procedure\">3.1. analytical procedure</h3>\n<div class=\"paragraph\">\n<p>detailed description of the steps required to perform an analytical test</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nAnalytical procedures include sample preparation, measurement, and\ncalculation steps.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_method_validation\">3.2. method validation</h3>\n<div class=\"paragraph\">\n<p>process of demonstrating that an analytical procedure is suitable for its\nintended purpose</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_specificity\">3.3. specificity</h3>\n<div class=\"paragraph\">\n<p>alt:[selectivity]</p>\n</div>\n<div class=\"paragraph\">\n<p>ability of an analytical procedure to assess unequivocally the analyte in the\npresence of components that may be expected to be present</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_accuracy\">3.4. accuracy</h3>\n<div class=\"paragraph\">\n<p>alt:[trueness]</p>\n</div>\n<div class=\"paragraph\">\n<p>closeness of agreement between the value found and the value accepted as true</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_precision\">3.5. precision</h3>\n<div class=\"paragraph\">\n<p>closeness of agreement between a series of measurements obtained from multiple\nsampling of the same homogeneous sample under prescribed conditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_repeatability\">3.6. repeatability</h3>\n<div class=\"paragraph\">\n<p>precision under the same operating conditions over a short interval of time</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_intermediate_precision\">3.7. intermediate precision</h3>\n<div class=\"paragraph\">\n<p>precision within-laboratory variations, such as different days, different\nanalysts, different equipment</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_reproducibility\">3.8. reproducibility</h3>\n<div class=\"paragraph\">\n<p>precision between laboratories</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_limit_of_detection\">3.9. limit of detection</h3>\n<div class=\"paragraph\">\n<p>alt:[LOD]</p>\n</div>\n<div class=\"paragraph\">\n<p>lowest amount of analyte that can be detected but not necessarily quantified</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_limit_of_quantitation\">3.10. limit of quantitation</h3>\n<div class=\"paragraph\">\n<p>alt:[LOQ]</p>\n</div>\n<div class=\"paragraph\">\n<p>lowest amount of analyte that can be quantitatively determined with suitable\nprecision and accuracy</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_linearity\">3.11. linearity</h3>\n<div class=\"paragraph\">\n<p>ability of an analytical procedure to obtain test results that are directly\nproportional to the concentration of analyte within a given range</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_range\">3.12. range</h3>\n<div class=\"paragraph\">\n<p>interval between upper and lower concentration amounts of analyte for which\nthe analytical procedure has suitable precision, accuracy, and linearity</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_robustness\">3.13. robustness</h3>\n<div class=\"paragraph\">\n<p>capacity of an analytical procedure to remain unaffected by small, but\ndeliberate variations in method parameters</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_reference_standard\">3.14. reference standard</h3>\n<div class=\"paragraph\">\n<p>substance or material characterized for use as a measurement standard in\nanalytical procedures</p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nReference standards may be primary standards or working standards.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_system_suitability\">3.15. system suitability</h3>\n<div class=\"paragraph\">\n<p>evaluation of the components of an analytical system to ensure that the system\nis operating within acceptable parameters before analysis</p>\n</div>\n<table id=\"table-validation-params\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Method validation parameters by test type</caption>\n<colgroup>\n<col style=\"width: 30%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 40%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Parameter</th>\n<th class=\"tableblock halign-left valign-top\">Identity tests</th>\n<th class=\"tableblock halign-left valign-top\">Quantitative tests</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Specificity</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Accuracy</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Precision (repeatability)</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Intermediate precision</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Linearity</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Range</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">LOD</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">When relevant</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">LOQ</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Not applicable</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Robustness</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Recommended</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Required</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"identity\">4. Identity testing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-identity-general\">4.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Identity testing shall be performed to confirm that plant material or\npreparations are authentic and correctly identified.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_methods_of_identity_testing\">4.2. Methods of identity testing</h3>\n<div class=\"sect3\">\n<h4 id=\"_macroscopic_examination\">4.2.1. Macroscopic examination</h4>\n<div class=\"paragraph\">\n<p>Macroscopic examination shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Visual assessment of color, form, and texture</p>\n</li>\n<li>\n<p>Odor assessment (where appropriate)</p>\n</li>\n<li>\n<p>Comparison with authenticated reference material or written description</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_microscopic_examination\">4.2.2. Microscopic examination</h4>\n<div class=\"paragraph\">\n<p>Microscopic examination shall include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Observation of characteristic cellular structures</p>\n</li>\n<li>\n<p>Comparison with reference material or photomicrographs</p>\n</li>\n<li>\n<p>Documentation of distinguishing features</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nMicroscopic examination is particularly important for powdered materials.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_chromatographic_methods\">4.2.3. Chromatographic methods</h4>\n<div class=\"paragraph\">\n<p>Chromatographic methods for identity testing shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Produce a fingerprint characteristic of the species</p>\n</li>\n<li>\n<p>Include comparison with authenticated reference material</p>\n</li>\n<li>\n<p>Document retention times and peak patterns</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptable chromatographic methods include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Thin-layer chromatography (TLC)</p>\n</li>\n<li>\n<p>High-performance liquid chromatography (HPLC)</p>\n</li>\n<li>\n<p>Gas chromatography (GC)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_spectroscopic_methods\">4.2.4. Spectroscopic methods</h4>\n<div class=\"paragraph\">\n<p>Spectroscopic methods may be used for identity testing, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Near-infrared spectroscopy (NIR)</p>\n</li>\n<li>\n<p>Fourier-transform infrared spectroscopy (FTIR)</p>\n</li>\n<li>\n<p>Nuclear magnetic resonance (NMR)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_dna_based_methods\">4.2.5. DNA-based methods</h4>\n<div class=\"paragraph\">\n<p>DNA-based authentication shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Use validated marker regions appropriate for the species</p>\n</li>\n<li>\n<p>Include appropriate positive and negative controls</p>\n</li>\n<li>\n<p>Be performed by competent laboratories</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-identity-acceptance\">4.3. Acceptance criteria</h3>\n<div class=\"paragraph\">\n<p>Material shall be considered positively identified when:</p>\n</div>\n<div class=\"paragraph\">\n<p>a) Results of identity testing are consistent with reference material or\n   documented characteristics\nb) No evidence of adulteration or substitution is detected\nc) Testing is performed by qualified personnel using validated methods</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"purity\">5. Purity testing</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-purity-general\">5.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Purity testing shall be performed to ensure that plant materials and\npreparations are free from unacceptable levels of contaminants.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-contaminants\">5.2. Contaminant categories</h3>\n<div class=\"sect3\">\n<h4 id=\"_foreign_matter\">5.2.1. Foreign matter</h4>\n<div class=\"paragraph\">\n<p>Testing for foreign matter shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Other plant species</p>\n</li>\n<li>\n<p>Plant parts other than the intended part</p>\n</li>\n<li>\n<p>Inert materials (soil, stones, etc.)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance criteria shall be specified based on pharmacopoeial standards or\nproduct specifications.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_heavy_metals\">5.2.2. Heavy metals</h4>\n<div class=\"paragraph\">\n<p>Heavy metal testing shall include, at minimum:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Lead (Pb)</p>\n</li>\n<li>\n<p>Cadmium (Cd)</p>\n</li>\n<li>\n<p>Mercury (Hg)</p>\n</li>\n<li>\n<p>Arsenic (As)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance limits shall be established based on regulatory requirements or\nrisk assessment.</p>\n</div>\n<div class=\"paragraph source\">\n<p><a href=\"#ICHQ3R8\">[ICH Q3(R8) Guideline for Elemental Impurities]</a></p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_pesticide_residues\">5.2.3. Pesticide residues</h4>\n<div class=\"paragraph\">\n<p>Pesticide residue testing shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Include pesticides commonly used in cultivation of the species</p>\n</li>\n<li>\n<p>Consider pesticides from previous land use</p>\n</li>\n<li>\n<p>Comply with regulatory limits for the intended market</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_mycotoxins\">5.2.4. Mycotoxins</h4>\n<div class=\"paragraph\">\n<p>Mycotoxin testing shall be performed when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Material is susceptible to fungal contamination</p>\n</li>\n<li>\n<p>Storage conditions may promote fungal growth</p>\n</li>\n<li>\n<p>Regulatory requirements apply</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Common mycotoxins to be tested include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Aflatoxins (B1, B2, G1, G2)</p>\n</li>\n<li>\n<p>Ochratoxin A</p>\n</li>\n<li>\n<p>Fumonisins</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_microbiological_contamination\">5.2.5. Microbiological contamination</h4>\n<div class=\"paragraph\">\n<p>Microbiological testing shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Total aerobic microbial count</p>\n</li>\n<li>\n<p>Yeast and mold count</p>\n</li>\n<li>\n<p>Specified pathogenic organisms</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Acceptance criteria shall be based on intended use and regulatory requirements.</p>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_solvent_residues\">5.2.6. Solvent residues</h4>\n<div class=\"paragraph\">\n<p>For extracts prepared using organic solvents, testing shall verify that\nresidual solvent levels are within acceptable limits.</p>\n</div>\n<table id=\"table-contaminants\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Purity testing requirements</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 35%;\">\n<col style=\"width: 40%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Contaminant</th>\n<th class=\"tableblock halign-left valign-top\">Test method</th>\n<th class=\"tableblock halign-left valign-top\">Acceptance criteria</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Foreign matter</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Visual/manual separation</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pharmacopoeial limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Heavy metals</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">ICP-MS, AAS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">ICH Q3D limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pesticides</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">GC-MS, LC-MS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Regulatory limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Mycotoxins</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">HPLC, LC-MS</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Regulatory limits</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Microbiology</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Plate count, PCR</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Pharmacopoeial limits</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"potency\">6. Potency determination</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-potency-general\">6.1. General requirements</h3>\n<div class=\"paragraph\">\n<p>Potency determination quantifies the concentration of active constituents or\nmarker compounds in plant materials and preparations.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-analyte-selection\">6.2. Analyte selection</h3>\n<div class=\"sect3\">\n<h4 id=\"_active_constituents\">6.2.1. Active constituents</h4>\n<div class=\"paragraph\">\n<p>When known active constituents are identified:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Quantification of active constituents is preferred</p>\n</li>\n<li>\n<p>Multiple actives may be quantified when relevant to efficacy</p>\n</li>\n<li>\n<p>Bioactive fractions may be quantified as a group</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_marker_compounds\">6.2.2. Marker compounds</h4>\n<div class=\"paragraph\">\n<p>When active constituents are not fully characterized:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Characteristic or analytical markers may be used</p>\n</li>\n<li>\n<p>The relationship between markers and activity shall be documented</p>\n</li>\n<li>\n<p>Selection of markers shall be scientifically justified</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-methods\">6.3. Quantitative methods</h3>\n<div class=\"sect3\">\n<h4 id=\"_chromatographic_methods_2\">6.3.1. Chromatographic methods</h4>\n<div class=\"paragraph\">\n<p>Chromatographic methods for potency determination shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Be validated for specificity, accuracy, precision, linearity, and range</p>\n</li>\n<li>\n<p>Use reference standards of known purity</p>\n</li>\n<li>\n<p>Include system suitability tests</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_spectrophotometric_methods\">6.3.2. Spectrophotometric methods</h4>\n<div class=\"paragraph\">\n<p>Spectrophotometric methods may be used when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Chromatographic methods are not practical</p>\n</li>\n<li>\n<p>The analyte or analyte group has characteristic absorption</p>\n</li>\n<li>\n<p>Interference from other components has been evaluated</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-specifications\">6.4. Specifications</h3>\n<div class=\"paragraph\">\n<p>Acceptance criteria for potency shall be established based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Historical data for the species</p>\n</li>\n<li>\n<p>Phytochemical variability</p>\n</li>\n<li>\n<p>Clinical or traditional use information</p>\n</li>\n<li>\n<p>Manufacturing requirements</p>\n</li>\n</ul>\n</div>\n<table id=\"table-specification-example\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 3. Example specification format</caption>\n<colgroup>\n<col style=\"width: 50%;\">\n<col style=\"width: 50%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Parameter</th>\n<th class=\"tableblock halign-left valign-top\">Acceptance criteria</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Marker compound A</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 2.0% and NMT 4.0% (dry basis)</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Marker compound B</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 0.5% (dry basis)</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Total phenolics (as gallic acid)</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">NLT 5.0% (dry basis)</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"validation\">7. Method validation</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-validation-requirements\">7.1. Validation requirements</h3>\n<div class=\"paragraph\">\n<p>Analytical methods shall be validated before use in quality control testing.\nValidation shall be documented and shall demonstrate that the method is fit\nfor its intended purpose.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-validation-parameters\">7.2. Validation parameters</h3>\n<div class=\"paragraph\">\n<p>Validation shall address the parameters specified in <a href=\"#table-validation-params\">Method validation parameters by test type</a>,\nas applicable to the method type.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-protocol\">7.3. Validation protocol</h3>\n<div class=\"paragraph\">\n<p>A validation protocol shall be prepared that includes:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Objective of the validation</p>\n</li>\n<li>\n<p>Description of the analytical procedure</p>\n</li>\n<li>\n<p>Parameters to be evaluated</p>\n</li>\n<li>\n<p>Acceptance criteria for each parameter</p>\n</li>\n<li>\n<p>Experimental design and sample requirements</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-report\">7.4. Validation report</h3>\n<div class=\"paragraph\">\n<p>A validation report shall be prepared that includes:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Summary of validation experiments performed</p>\n</li>\n<li>\n<p>Raw data and statistical analysis</p>\n</li>\n<li>\n<p>Comparison of results to acceptance criteria</p>\n</li>\n<li>\n<p>Conclusion on method suitability</p>\n</li>\n<li>\n<p>Any deviations from the protocol and their impact</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-revalidation\">7.5. Revalidation</h3>\n<div class=\"paragraph\">\n<p>Methods shall be revalidated when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Changes are made to the analytical procedure</p>\n</li>\n<li>\n<p>The method is transferred to another laboratory</p>\n</li>\n<li>\n<p>Results indicate the method is no longer performing adequately</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"reporting\">8. Reporting of results</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-report-content\">8.1. Certificate of analysis</h3>\n<div class=\"paragraph\">\n<p>A certificate of analysis shall be provided for each batch tested, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Identity of the material tested</p>\n</li>\n<li>\n<p>Batch or lot number</p>\n</li>\n<li>\n<p>Date of testing</p>\n</li>\n<li>\n<p>Reference to test methods used</p>\n</li>\n<li>\n<p>Test results with units</p>\n</li>\n<li>\n<p>Acceptance criteria</p>\n</li>\n<li>\n<p>Pass/fail determination</p>\n</li>\n<li>\n<p>Name and signature of authorized person</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-result-expression\">8.2. Expression of results</h3>\n<div class=\"paragraph\">\n<p>Results shall be expressed:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>In appropriate units (e.g., % w/w, mg/g, ppm)</p>\n</li>\n<li>\n<p>On a consistent basis (dry weight or as-is)</p>\n</li>\n<li>\n<p>With appropriate significant figures</p>\n</li>\n<li>\n<p>With measurement uncertainty when required</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-records\">8.3. Record retention</h3>\n<div class=\"paragraph\">\n<p>Analytical records shall be retained for a period defined by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Regulatory requirements</p>\n</li>\n<li>\n<p>Product shelf life</p>\n</li>\n<li>\n<p>Quality management system requirements</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nA minimum retention period of one year beyond product shelf life is\nrecommended.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[[[ICHQ2R1,ICH Q2(R1) Validation of Analytical Procedures: Text and\nMethodology]]]</p>\n</li>\n<li>\n<p><a id=\"FDAGuidance\"></a>[FDA Guidance for Industry: Botanical Drug Development],\nU.S. Food and Drug Administration, 2016</p>\n</li>\n<li>\n<p><a id=\"EMAGuidance\"></a>[EMA Guideline on Quality of Herbal Medicinal Products],\nEuropean Medicines Agency</p>\n</li>\n<li>\n<p><a id=\"AOAC\"></a>[AOAC Official Methods of Analysis], Association of Official\nAnalytical Chemists</p>\n</li>\n<li>\n<p><a id=\"ICHQ3D\"></a>[ICH Q3D Guideline for Elemental Impurities]</p>\n</li>\n<li>\n<p>[[[USP2232,USP General Chapter &lt;2232&gt; Elemental Contaminants in Dietary\nSupplements]]]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_analytical_procedure",
+          "title": "analytical procedure",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_method_validation",
+          "title": "method validation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_specificity",
+          "title": "specificity",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_accuracy",
+          "title": "accuracy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_precision",
+          "title": "precision",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_repeatability",
+          "title": "repeatability",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_intermediate_precision",
+          "title": "intermediate precision",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_reproducibility",
+          "title": "reproducibility",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_limit_of_detection",
+          "title": "limit of detection",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_limit_of_quantitation",
+          "title": "limit of quantitation",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_linearity",
+          "title": "linearity",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_range",
+          "title": "range",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_robustness",
+          "title": "robustness",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_reference_standard",
+          "title": "reference standard",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_system_suitability",
+          "title": "system suitability",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "identity",
+      "title": "Identity testing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-identity-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_methods_of_identity_testing",
+          "title": "Methods of identity testing",
+          "level": 2,
+          "children": [
+            {
+              "id": "_macroscopic_examination",
+              "title": "Macroscopic examination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_microscopic_examination",
+              "title": "Microscopic examination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_chromatographic_methods",
+              "title": "Chromatographic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_spectroscopic_methods",
+              "title": "Spectroscopic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_dna_based_methods",
+              "title": "DNA-based methods",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-identity-acceptance",
+          "title": "Acceptance criteria",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "purity",
+      "title": "Purity testing",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-purity-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-contaminants",
+          "title": "Contaminant categories",
+          "level": 2,
+          "children": [
+            {
+              "id": "_foreign_matter",
+              "title": "Foreign matter",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_heavy_metals",
+              "title": "Heavy metals",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_pesticide_residues",
+              "title": "Pesticide residues",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_mycotoxins",
+              "title": "Mycotoxins",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_microbiological_contamination",
+              "title": "Microbiological contamination",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_solvent_residues",
+              "title": "Solvent residues",
+              "level": 3,
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "potency",
+      "title": "Potency determination",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-potency-general",
+          "title": "General requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-analyte-selection",
+          "title": "Analyte selection",
+          "level": 2,
+          "children": [
+            {
+              "id": "_active_constituents",
+              "title": "Active constituents",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_marker_compounds",
+              "title": "Marker compounds",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-methods",
+          "title": "Quantitative methods",
+          "level": 2,
+          "children": [
+            {
+              "id": "_chromatographic_methods_2",
+              "title": "Chromatographic methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_spectrophotometric_methods",
+              "title": "Spectrophotometric methods",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-specifications",
+          "title": "Specifications",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "validation",
+      "title": "Method validation",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-validation-requirements",
+          "title": "Validation requirements",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-validation-parameters",
+          "title": "Validation parameters",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-protocol",
+          "title": "Validation protocol",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-report",
+          "title": "Validation report",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-revalidation",
+          "title": "Revalidation",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "reporting",
+      "title": "Reporting of results",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-report-content",
+          "title": "Certificate of analysis",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-result-expression",
+          "title": "Expression of results",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-records",
+          "title": "Record retention",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Analytical Methods for Phytomedicine\n:docnumber: 0300\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Analytical Methods for Phytomedicine\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 4\n:technical-committee: Analytical Methods\n:library-ics: 07.100.01;11.120\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-identity.adoc[]\n\ninclude::sections/05-purity.adoc[]\n\ninclude::sections/06-potency.adoc[]\n\ninclude::sections/07-validation.adoc[]\n\ninclude::sections/08-reporting.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/src/content/standards/SIPM-0400.json
+++ b/src/content/standards/SIPM-0400.json
@@ -1,0 +1,303 @@
+{
+  "id": "SIPM-0400",
+  "title": "Clinical Evidence for Phytomedicine",
+  "attributes": {
+    "docnumber": "0400",
+    "partnumber": "1",
+    "edition": "1",
+    "revdate": "2026-02-17",
+    "copyright-year": "2026",
+    "language": "en",
+    "title-intro-en": "SIPM Standards",
+    "title-main-en": "Clinical Evidence for Phytomedicine",
+    "title-part-en": "General requirements",
+    "doctype": "international-standard",
+    "docstage": "60",
+    "docsubstage": "60",
+    "technical-committee": "Clinical Evidence",
+    "library-ics": "11.120.10;03.100.01"
+  },
+  "html": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#intro\">1. Introduction</a></li>\n<li><a href=\"#scope\">2. Scope</a></li>\n<li><a href=\"#norm-refs\">Normative references</a></li>\n<li><a href=\"#terms\">3. Terms and definitions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_clinical_evidence\">3.1. clinical evidence</a></li>\n<li><a href=\"#_clinical_trial\">3.2. clinical trial</a></li>\n<li><a href=\"#_randomized_controlled_trial\">3.3. randomized controlled trial</a></li>\n<li><a href=\"#_observational_study\">3.4. observational study</a></li>\n<li><a href=\"#_systematic_review\">3.5. systematic review</a></li>\n<li><a href=\"#_meta_analysis\">3.6. meta-analysis</a></li>\n<li><a href=\"#_traditional_use_evidence\">3.7. traditional use evidence</a></li>\n<li><a href=\"#_well_established_use\">3.8. well-established use</a></li>\n<li><a href=\"#_efficacy\">3.9. efficacy</a></li>\n<li><a href=\"#_effectiveness\">3.10. effectiveness</a></li>\n<li><a href=\"#_safety_profile\">3.11. safety profile</a></li>\n<li><a href=\"#_pharmacovigilance\">3.12. pharmacovigilance</a></li>\n<li><a href=\"#_investigational_product\">3.13. investigational product</a></li>\n</ul>\n</li>\n<li><a href=\"#evidence-hierarchy\">4. Evidence hierarchy</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-evidence-levels\">4.1. Levels of evidence</a></li>\n<li><a href=\"#sec-evidence-weighting\">4.2. Evidence weighting</a></li>\n<li><a href=\"#sec-traditional-evidence\">4.3. Traditional use evidence</a></li>\n</ul>\n</li>\n<li><a href=\"#study-design\">5. Study design considerations</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-product-characterization\">5.1. Product characterization</a></li>\n<li><a href=\"#sec-study-population\">5.2. Study population</a></li>\n<li><a href=\"#sec-outcome-measures\">5.3. Outcome measures</a></li>\n<li><a href=\"#sec-control-interventions\">5.4. Control interventions</a></li>\n<li><a href=\"#sec-study-duration\">5.5. Study duration</a></li>\n</ul>\n</li>\n<li><a href=\"#quality-assessment\">6. Quality assessment of clinical studies</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-quality-criteria\">6.1. Quality criteria</a></li>\n<li><a href=\"#sec-quality-domains\">6.2. Quality domains for RCTs</a></li>\n<li><a href=\"#sec-transparency\">6.3. Transparency requirements</a></li>\n</ul>\n</li>\n<li><a href=\"#reporting\">7. Reporting standards</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#sec-reporting-guidelines\">7.1. Reporting guidelines</a></li>\n<li><a href=\"#sec-reporting-elements\">7.2. Essential reporting elements</a></li>\n<li><a href=\"#sec-data-sharing\">7.3. Data sharing</a></li>\n</ul>\n</li>\n<li><a href=\"#bib\">Bibliography</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<div class=\"title\">Foreword</div>\n<p>The Society for Integrative Phytomedicine (SIPM) is an international organization\ndedicated to the development of standards for phytomedicine, medicinal fungi,\nand related natural health products. The work of preparing SIPM Standards is\ncarried out through technical committees composed of experts from academia,\nindustry, regulatory bodies, and healthcare practice.</p>\n</div>\n<div class=\"paragraph\">\n<p>The procedures used to develop this document and those intended for its further\nmaintenance are described in the SIPM Directives, Part 1. In particular, the\ndifferent approval criteria needed for the different types of SIPM documents\nshould be noted. This document was drafted in accordance with the editorial\nrules of the SIPM Directives, Part 2.</p>\n</div>\n<div class=\"paragraph\">\n<p>SIPM draws attention to the possibility that the implementation of this document\nmay involve the use of intellectual property. SIPM takes no position concerning\nthe evidence, validity or applicability of any claimed intellectual property\nrights in respect thereof. As of the date of publication of this document, SIPM\nhad not received notice of any patents which may be required to implement this\ndocument. However, implementers are cautioned that this may not represent the\nlatest information.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any trade name used in this document is information given for the convenience of\nusers and does not constitute an endorsement.</p>\n</div>\n<div class=\"paragraph\">\n<p>For an explanation of the voluntary nature of standards, the meaning of SIPM\nspecific terms and expressions related to conformity assessment, as well as\ninformation about SIPM&#8217;s adherence to the World Trade Organization (WTO)\nprinciples in the Technical Barriers to Trade (TBT), see <a href=\"https://sipm.org/about\" class=\"bare\">https://sipm.org/about</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document was prepared by Technical Committee TC 5,\n<em>Clinical Evidence</em>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This is the first edition of SIPM 0400.</p>\n</div>\n<div class=\"paragraph\">\n<p>A list of all parts in the SIPM 0400 series can be found on the SIPM\nwebsite.</p>\n</div>\n<div class=\"paragraph\">\n<p>Any feedback or questions on this document should be directed to the SIPM\nSecretariat at <a href=\"mailto:standards@sipm.org\">standards@sipm.org</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"intro\">1. Introduction</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The establishment of clinical evidence is fundamental to the responsible use of\nphytomedicine in healthcare. While traditional use provides valuable historical\ncontext, modern evidence-based practice requires rigorous clinical research to\nestablish safety and efficacy.</p>\n</div>\n<div class=\"paragraph\">\n<p>This document provides a framework for the generation, evaluation, and reporting\nof clinical evidence for phytomedicine products. It recognizes the unique\nchallenges of clinical research in phytomedicine, including:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Complexity of multi-component botanical preparations</p>\n</li>\n<li>\n<p>Variability in product composition between studies</p>\n</li>\n<li>\n<p>Integration of traditional knowledge with modern research methods</p>\n</li>\n<li>\n<p>Ethical considerations in studying traditional remedies</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>The standard addresses the complete evidence generation process:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Classification of evidence types and their relative weight</p>\n</li>\n<li>\n<p>Study design considerations specific to phytomedicine</p>\n</li>\n<li>\n<p>Quality assessment of clinical studies</p>\n</li>\n<li>\n<p>Transparent reporting of methods and results</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document is intended to support:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Researchers designing clinical studies of phytomedicines</p>\n</li>\n<li>\n<p>Regulatory bodies evaluating marketing authorization applications</p>\n</li>\n<li>\n<p>Healthcare professionals assessing evidence for clinical practice</p>\n</li>\n<li>\n<p>Manufacturers developing evidence-based products</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"scope\">2. Scope</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This document specifies requirements for the generation, evaluation, and\nreporting of clinical evidence for phytomedicine products.</p>\n</div>\n<div class=\"paragraph\">\n<p>It is applicable to:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Clinical trials and observational studies of phytomedicines</p>\n</li>\n<li>\n<p>Evidence synthesis and systematic reviews</p>\n</li>\n<li>\n<p>Assessment of traditional use evidence</p>\n</li>\n<li>\n<p>Regulatory submissions and health claims substantiation</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document covers:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Herbal medicinal products</p>\n</li>\n<li>\n<p>Medicinal fungi products</p>\n</li>\n<li>\n<p>Traditional herbal preparations</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This document does not cover:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Preclinical (in vitro and animal) studies</p>\n</li>\n<li>\n<p>Specific disease conditions or products</p>\n</li>\n<li>\n<p>Regulatory requirements for specific jurisdictions</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"norm-refs\">Normative references</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The following documents are referred to in the text in such a way that some or\nall of their content constitutes requirements of this document. For dated\nreferences, only the edition cited applies. For undated references, the latest\nedition of the referenced document (including any amendments) applies.</p>\n</div>\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p><a id=\"ICHGCP\"></a>[ICH E6(R2) Good Clinical Practice]</p>\n</li>\n<li>\n<p>[[[CONSORT,CONSORT 2010 Statement: Updated Guidelines for Reporting Parallel\nGroup Randomized Trials]]]</p>\n</li>\n<li>\n<p><a id=\"PRISMA\"></a>[PRISMA Statement for Reporting Systematic Reviews]</p>\n</li>\n<li>\n<p>[[[GRADE,Grading of Recommendations Assessment, Development and Evaluation\n(GRADE) Handbook]]]</p>\n</li>\n<li>\n<p>[[[WHOTM,WHO General Guidelines for Methodologies on Research and Evaluation\nof Traditional Medicine]]]</p>\n</li>\n<li>\n<p>[[[DECLHELSINKI,Declaration of Helsinki: Ethical Principles for Medical\nResearch Involving Human Subjects]]]</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"terms\">3. Terms and definitions</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>For the purposes of this document, the following terms and definitions apply.\nTerms defined in SIPM-0001 also apply where relevant.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_clinical_evidence\">3.1. clinical evidence</h3>\n<div class=\"paragraph\">\n<p>information derived from clinical research that contributes to the assessment\nof safety and efficacy of a phytomedicine</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_clinical_trial\">3.2. clinical trial</h3>\n<div class=\"paragraph\">\n<p>alt:[interventional study]</p>\n</div>\n<div class=\"paragraph\">\n<p>research study that prospectively assigns human participants to one or more\ninterventions to evaluate the effects on health outcomes</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_randomized_controlled_trial\">3.3. randomized controlled trial</h3>\n<div class=\"paragraph\">\n<p>alt:[RCT]</p>\n</div>\n<div class=\"paragraph\">\n<p>clinical trial in which participants are allocated to intervention groups by\nchance (randomization)</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_observational_study\">3.4. observational study</h3>\n<div class=\"paragraph\">\n<p>research study in which participants are observed and outcomes measured without\nassignment of interventions by the investigator</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_systematic_review\">3.5. systematic review</h3>\n<div class=\"paragraph\">\n<p>review that uses systematic methods to identify, select, and critically\nappraise relevant research, and to collect and analyze data from included studies</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_meta_analysis\">3.6. meta-analysis</h3>\n<div class=\"paragraph\">\n<p>statistical analysis that combines the results of multiple scientific studies</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_traditional_use_evidence\">3.7. traditional use evidence</h3>\n<div class=\"paragraph\">\n<p>documentation of the historical use of a phytomedicine over one or more\ngenerations within a specific cultural context</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_well_established_use\">3.8. well-established use</h3>\n<div class=\"paragraph\">\n<p>regulatory concept referring to a medicinal product with recognized safety and\nefficacy based on at least 10 years of use in a specific jurisdiction</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_efficacy\">3.9. efficacy</h3>\n<div class=\"paragraph\">\n<p>ability of a phytomedicine to produce a beneficial therapeutic effect under\ncontrolled conditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_effectiveness\">3.10. effectiveness</h3>\n<div class=\"paragraph\">\n<p>degree to which a phytomedicine produces a beneficial effect under real-world\nconditions</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_safety_profile\">3.11. safety profile</h3>\n<div class=\"paragraph\">\n<p>comprehensive summary of known and potential adverse effects, contraindications,\nand drug interactions associated with a phytomedicine</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_pharmacovigilance\">3.12. pharmacovigilance</h3>\n<div class=\"paragraph\">\n<p>science and activities relating to the detection, assessment, understanding,\nand prevention of adverse effects or other drug-related problems</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_investigational_product\">3.13. investigational product</h3>\n<div class=\"paragraph\">\n<p>phytomedicine being tested or used as a reference in a clinical trial</p>\n</div>\n<table id=\"table-study-types\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 1. Characteristics of common study designs</caption>\n<colgroup>\n<col style=\"width: 25%;\">\n<col style=\"width: 30%;\">\n<col style=\"width: 45%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Study type</th>\n<th class=\"tableblock halign-left valign-top\">Key features</th>\n<th class=\"tableblock halign-left valign-top\">Strengths/limitations</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trial</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Random allocation, control group, blinding</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">High internal validity; may have limited external validity</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized controlled trial</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Control group without randomization</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Practical for some settings; potential for confounding</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cohort study</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Follows groups over time</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Good for rare exposures; potential for confounding</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case-control study</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Compares cases with controls</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Good for rare outcomes; recall bias</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case series</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Description of multiple cases</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Hypothesis generation; no control group</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"evidence-hierarchy\">4. Evidence hierarchy</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-evidence-levels\">4.1. Levels of evidence</h3>\n<div class=\"paragraph\">\n<p>Evidence for phytomedicine safety and efficacy shall be classified according\nto a hierarchical system that reflects the relative strength of different\nevidence types.</p>\n</div>\n<table id=\"table-evidence-levels\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 2. Evidence hierarchy for phytomedicine</caption>\n<colgroup>\n<col style=\"width: 15%;\">\n<col style=\"width: 25%;\">\n<col style=\"width: 60%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Level</th>\n<th class=\"tableblock halign-left valign-top\">Evidence type</th>\n<th class=\"tableblock halign-left valign-top\">Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level I</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Systematic reviews of RCTs</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Meta-analyses and systematic reviews of randomized controlled trials</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level II</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trials</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Well-designed randomized controlled trials with adequate sample size</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level III</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized controlled studies</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Controlled studies without randomization, cohort studies</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level IV</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Case series and case reports</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Uncontrolled studies, case series, case reports</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Level V</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Traditional use evidence</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Documented historical use, ethnobotanical records, traditional knowledge</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-evidence-weighting\">4.2. Evidence weighting</h3>\n<div class=\"paragraph\">\n<p>When evaluating the totality of evidence, the following factors shall be\nconsidered:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Study design (higher levels provide stronger evidence)</p>\n</li>\n<li>\n<p>Methodological quality of individual studies</p>\n</li>\n<li>\n<p>Consistency of findings across studies</p>\n</li>\n<li>\n<p>Directness of evidence to the population and intervention of interest</p>\n</li>\n<li>\n<p>Precision of effect estimates</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-traditional-evidence\">4.3. Traditional use evidence</h3>\n<div class=\"paragraph\">\n<p>Traditional use evidence may be considered as supporting evidence when:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>The phytomedicine has been used for a defined period (typically 30+ years)</p>\n</li>\n<li>\n<p>The conditions of use (dose, route, population) are documented</p>\n</li>\n<li>\n<p>Safety information is available from traditional use</p>\n</li>\n<li>\n<p>The traditional preparation method is relevant to the modern product</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nTraditional use evidence alone is generally insufficient to support\nefficacy claims in most regulatory jurisdictions, but may support safety\nand guide clinical research design.\n</td>\n</tr>\n</table>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"study-design\">5. Study design considerations</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-product-characterization\">5.1. Product characterization</h3>\n<div class=\"sect3\">\n<h4 id=\"_identity_and_quality\">5.1.1. Identity and quality</h4>\n<div class=\"paragraph\">\n<p>The investigational phytomedicine product shall be fully characterized,\nincluding:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Botanical identity (species, plant part, geographic origin)</p>\n</li>\n<li>\n<p>Manufacturing process and quality control</p>\n</li>\n<li>\n<p>Phytochemical profile (marker compounds, batch-to-batch consistency)</p>\n</li>\n<li>\n<p>Specifications and certificate of analysis</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\nPoor product characterization is a common limitation of published\nphytomedicine clinical studies.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_standardization\">5.1.2. Standardization</h4>\n<div class=\"paragraph\">\n<p>When applicable, the study product shall be standardized to defined marker\ncompounds or active constituents.</p>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-study-population\">5.2. Study population</h3>\n<div class=\"sect3\">\n<h4 id=\"_participant_selection\">5.2.1. Participant selection</h4>\n<div class=\"paragraph\">\n<p>The study population shall be defined by:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Inclusion criteria appropriate to the research question</p>\n</li>\n<li>\n<p>Exclusion criteria that address safety concerns</p>\n</li>\n<li>\n<p>Relevant demographic and clinical characteristics</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_sample_size\">5.2.2. Sample size</h4>\n<div class=\"paragraph\">\n<p>Sample size calculations shall be performed and documented, based on:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Expected effect size</p>\n</li>\n<li>\n<p>Variability in primary outcome measures</p>\n</li>\n<li>\n<p>Statistical power requirements</p>\n</li>\n<li>\n<p>Significance level</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-outcome-measures\">5.3. Outcome measures</h3>\n<div class=\"sect3\">\n<h4 id=\"_primary_outcomes\">5.3.1. Primary outcomes</h4>\n<div class=\"paragraph\">\n<p>Primary outcomes shall:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Be clinically relevant to the indication</p>\n</li>\n<li>\n<p>Be valid, reliable, and responsive to change</p>\n</li>\n<li>\n<p>Be specified a priori in the study protocol</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_secondary_outcomes\">5.3.2. Secondary outcomes</h4>\n<div class=\"paragraph\">\n<p>Secondary outcomes may include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Additional clinical measures</p>\n</li>\n<li>\n<p>Quality of life assessments</p>\n</li>\n<li>\n<p>Biomarkers</p>\n</li>\n<li>\n<p>Safety outcomes</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-control-interventions\">5.4. Control interventions</h3>\n<div class=\"paragraph\">\n<p>Control interventions may include:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Placebo (when ethically appropriate)</p>\n</li>\n<li>\n<p>Active comparator (standard treatment)</p>\n</li>\n<li>\n<p>No treatment (for pragmatic trials)</p>\n</li>\n<li>\n<p>Dose comparison</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Placebo control shall match the investigational product in appearance, taste,\nand smell where possible.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-study-duration\">5.5. Study duration</h3>\n<div class=\"paragraph\">\n<p>Study duration shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Appropriate to the indication and expected time to effect</p>\n</li>\n<li>\n<p>Sufficient to detect both efficacy and safety signals</p>\n</li>\n<li>\n<p>Justified in the study protocol</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>For chronic conditions, long-term safety data (6+ months) is typically required.</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"quality-assessment\">6. Quality assessment of clinical studies</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-quality-criteria\">6.1. Quality criteria</h3>\n<div class=\"paragraph\">\n<p>The methodological quality of clinical studies shall be assessed using\nvalidated assessment tools appropriate to the study design.</p>\n</div>\n<table id=\"table-quality-tools\" class=\"tableblock frame-all grid-all stretch\">\n<caption class=\"title\">Table 3. Quality assessment tools by study design</caption>\n<colgroup>\n<col style=\"width: 40%;\">\n<col style=\"width: 60%;\">\n</colgroup>\n<thead>\n<tr>\n<th class=\"tableblock halign-left valign-top\">Study design</th>\n<th class=\"tableblock halign-left valign-top\">Assessment tool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Randomized controlled trials</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Cochrane Risk of Bias tool, Jadad scale</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Non-randomized studies</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Newcastle-Ottawa Scale, ROBINS-I</p></td>\n</tr>\n<tr>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">Systematic reviews</p></td>\n<td class=\"tableblock halign-left valign-top\"><p class=\"tableblock\">AMSTAR 2, ROBIS</p></td>\n</tr>\n</tbody>\n</table>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-quality-domains\">6.2. Quality domains for RCTs</h3>\n<div class=\"paragraph\">\n<p>Quality assessment of randomized controlled trials shall address:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Random sequence generation</p>\n</li>\n<li>\n<p>Allocation concealment</p>\n</li>\n<li>\n<p>Blinding of participants and personnel</p>\n</li>\n<li>\n<p>Blinding of outcome assessment</p>\n</li>\n<li>\n<p>Incomplete outcome data</p>\n</li>\n<li>\n<p>Selective reporting</p>\n</li>\n<li>\n<p>Other sources of bias</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-transparency\">6.3. Transparency requirements</h3>\n<div class=\"paragraph\">\n<p>To support quality assessment, clinical studies shall be:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Registered in a public trials registry before enrollment</p>\n</li>\n<li>\n<p>Conducted in accordance with Good Clinical Practice (GCP)</p>\n</li>\n<li>\n<p>Reported completely and transparently</p>\n</li>\n<li>\n<p>Made available through open access when possible</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"reporting\">7. Reporting standards</h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"sec-reporting-guidelines\">7.1. Reporting guidelines</h3>\n<div class=\"paragraph\">\n<p>Clinical studies of phytomedicines shall be reported in accordance with\nrecognized reporting guidelines:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>CONSORT for randomized controlled trials</p>\n</li>\n<li>\n<p>STROBE for observational studies</p>\n</li>\n<li>\n<p>PRISMA for systematic reviews</p>\n</li>\n<li>\n<p>TREND for non-randomized evaluations</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-reporting-elements\">7.2. Essential reporting elements</h3>\n<div class=\"paragraph\">\n<p>Reports of phytomedicine clinical studies shall include:</p>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_product_information\">7.2.1. Product information</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Complete botanical identification (species, authority, plant part)</p>\n</li>\n<li>\n<p>Extract type and method of preparation</p>\n</li>\n<li>\n<p>Drug-to-extract ratio (for extracts)</p>\n</li>\n<li>\n<p>Standardization information (marker compounds and levels)</p>\n</li>\n<li>\n<p>Dose and dosing regimen</p>\n</li>\n<li>\n<p>Manufacturer and batch numbers</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_study_methods\">7.2.2. Study methods</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Study design and justification</p>\n</li>\n<li>\n<p>Participant eligibility criteria</p>\n</li>\n<li>\n<p>Interventions for each group</p>\n</li>\n<li>\n<p>Outcome measures and timing</p>\n</li>\n<li>\n<p>Sample size calculation</p>\n</li>\n<li>\n<p>Randomization and blinding methods</p>\n</li>\n<li>\n<p>Statistical methods</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect3\">\n<h4 id=\"_results\">7.2.3. Results</h4>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Participant flow (recruitment, allocation, follow-up, analysis)</p>\n</li>\n<li>\n<p>Baseline characteristics</p>\n</li>\n<li>\n<p>Results for primary and secondary outcomes</p>\n</li>\n<li>\n<p>Harms and adverse events</p>\n</li>\n<li>\n<p>Limitations</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"sec-data-sharing\">7.3. Data sharing</h3>\n<div class=\"paragraph\">\n<p>To support evidence synthesis and transparency:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Individual participant data should be made available where possible</p>\n</li>\n<li>\n<p>Study protocols and statistical analysis plans should be published</p>\n</li>\n<li>\n<p>Negative and inconclusive results should be reported</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"bib\">Bibliography</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist bibliography\">\n<ul class=\"bibliography\">\n<li>\n<p>[<a id=\"CONSORT2010\"></a>, CONSORT 2010 Statement: Updated guidelines for\nreporting parallel group randomized trials. <em>BMJ</em> 2010, <strong>340</strong>, c332</p>\n</li>\n<li>\n<p>[<a id=\"GRADEhandbook\"></a>, <em>GRADE Handbook</em>. Cochrane, 2013</p>\n</li>\n<li>\n<p>[[[FWHO2000,WHO General Guidelines for Methodologies on Research and\nEvaluation of Traditional Medicine]]], World Health Organization, Geneva, 2000</p>\n</li>\n<li>\n<p>[[[EichEich D.#]], Clinical trials in phytomedicine: Challenges and\nopportunities. <em>Phytomedicine</em> 2015, <strong>22</strong> (12) pp. 1061-1065</p>\n</li>\n<li>\n<p>[[[GagnierGagnier J.J.#]], Improving the quality of reporting of randomized\ncontrolled trials in phytomedicine. <em>Phytomedicine</em> 2006, <strong>13</strong> (4) pp. 274-282</p>\n</li>\n</ul>\n</div>\n</div>\n</div>",
+  "toc": [
+    {
+      "id": "intro",
+      "title": "Introduction",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "scope",
+      "title": "Scope",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "norm-refs",
+      "title": "Normative references",
+      "level": 1,
+      "children": []
+    },
+    {
+      "id": "terms",
+      "title": "Terms and definitions",
+      "level": 1,
+      "children": [
+        {
+          "id": "_clinical_evidence",
+          "title": "clinical evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_clinical_trial",
+          "title": "clinical trial",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_randomized_controlled_trial",
+          "title": "randomized controlled trial",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_observational_study",
+          "title": "observational study",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_systematic_review",
+          "title": "systematic review",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_meta_analysis",
+          "title": "meta-analysis",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_traditional_use_evidence",
+          "title": "traditional use evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_well_established_use",
+          "title": "well-established use",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_efficacy",
+          "title": "efficacy",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_effectiveness",
+          "title": "effectiveness",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_safety_profile",
+          "title": "safety profile",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_pharmacovigilance",
+          "title": "pharmacovigilance",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "_investigational_product",
+          "title": "investigational product",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "evidence-hierarchy",
+      "title": "Evidence hierarchy",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-evidence-levels",
+          "title": "Levels of evidence",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-evidence-weighting",
+          "title": "Evidence weighting",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-traditional-evidence",
+          "title": "Traditional use evidence",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "study-design",
+      "title": "Study design considerations",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-product-characterization",
+          "title": "Product characterization",
+          "level": 2,
+          "children": [
+            {
+              "id": "_identity_and_quality",
+              "title": "Identity and quality",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_standardization",
+              "title": "Standardization",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-study-population",
+          "title": "Study population",
+          "level": 2,
+          "children": [
+            {
+              "id": "_participant_selection",
+              "title": "Participant selection",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_sample_size",
+              "title": "Sample size",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-outcome-measures",
+          "title": "Outcome measures",
+          "level": 2,
+          "children": [
+            {
+              "id": "_primary_outcomes",
+              "title": "Primary outcomes",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_secondary_outcomes",
+              "title": "Secondary outcomes",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-control-interventions",
+          "title": "Control interventions",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-study-duration",
+          "title": "Study duration",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "quality-assessment",
+      "title": "Quality assessment of clinical studies",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-quality-criteria",
+          "title": "Quality criteria",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-quality-domains",
+          "title": "Quality domains for RCTs",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-transparency",
+          "title": "Transparency requirements",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "reporting",
+      "title": "Reporting standards",
+      "level": 1,
+      "children": [
+        {
+          "id": "sec-reporting-guidelines",
+          "title": "Reporting guidelines",
+          "level": 2,
+          "children": []
+        },
+        {
+          "id": "sec-reporting-elements",
+          "title": "Essential reporting elements",
+          "level": 2,
+          "children": [
+            {
+              "id": "_product_information",
+              "title": "Product information",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_study_methods",
+              "title": "Study methods",
+              "level": 3,
+              "children": []
+            },
+            {
+              "id": "_results",
+              "title": "Results",
+              "level": 3,
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "sec-data-sharing",
+          "title": "Data sharing",
+          "level": 2,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "bib",
+      "title": "Bibliography",
+      "level": 1,
+      "children": []
+    }
+  ],
+  "raw": "= Clinical Evidence for Phytomedicine\n:docnumber: 0400\n:partnumber: 1\n:edition: 1\n:revdate: 2026-02-17\n:copyright-year: 2026\n:language: en\n:title-intro-en: SIPM Standards\n:title-main-en: Clinical Evidence for Phytomedicine\n:title-part-en: General requirements\n:doctype: international-standard\n:docstage: 60\n:docsubstage: 60\n:technical-committee-number: 5\n:technical-committee: Clinical Evidence\n:library-ics: 11.120.10;03.100.01\n:mn-document-class: iso\n:mn-output-extensions: xml,html,doc,pdf\n\ninclude::sections/00-foreword.adoc[]\n\ninclude::sections/00-introduction.adoc[]\n\ninclude::sections/01-scope.adoc[]\n\ninclude::sections/02-normref.adoc[]\n\ninclude::sections/03-terms.adoc[]\n\ninclude::sections/04-evidence-hierarchy.adoc[]\n\ninclude::sections/05-study-design.adoc[]\n\ninclude::sections/06-quality-assessment.adoc[]\n\ninclude::sections/07-reporting.adoc[]\n\ninclude::sections/b0-bibliography.adoc[]\n"
+}

--- a/src/content/standards/index.json
+++ b/src/content/standards/index.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "SIPM-0001",
+    "title": "Terminology for Phytomedicine",
+    "number": "SIPM-0001",
+    "category": "foundation",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0002",
+    "title": "Medicinal Fungi Taxonomy",
+    "number": "SIPM-0002",
+    "category": "foundation",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0200",
+    "title": "Agricultural Practices for Medicinal Plants",
+    "number": "SIPM-0200",
+    "category": "quality",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0300",
+    "title": "Analytical Methods for Phytomedicine",
+    "number": "SIPM-0300",
+    "category": "science",
+    "status": "published",
+    "date": "2026-02-17"
+  },
+  {
+    "id": "SIPM-0400",
+    "title": "Clinical Evidence for Phytomedicine",
+    "number": "SIPM-0400",
+    "category": "science",
+    "status": "published",
+    "date": "2026-02-17"
+  }
+]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -80,7 +80,14 @@ export const routes = [
     ]
   },
 
-  // Individual standard pages
+  // Individual standard pages (new StandardView for AsciiDoc rendering)
+  {
+    path: '/standards/:category/:id',
+    name: 'standard-view',
+    component: () => import('@/views/standards/StandardView.vue')
+  },
+
+  // Legacy standard detail pages (redirect or show placeholder)
   {
     path: '/standards/foundation/:slug',
     name: 'standard-foundation',
@@ -141,6 +148,18 @@ export const routes = [
         component: () => import('@/views/members/DirectoryView.vue')
       }
     ]
+  },
+
+  // Legal pages
+  {
+    path: '/privacy',
+    name: 'privacy',
+    component: () => import('@/views/PrivacyView.vue')
+  },
+  {
+    path: '/terms',
+    name: 'terms',
+    component: () => import('@/views/TermsView.vue')
   },
 
   // 404 - must be last

--- a/src/views/PrivacyView.vue
+++ b/src/views/PrivacyView.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="content-page">
+    <h1 class="page-title">Privacy Policy</h1>
+
+    <div class="content-body">
+      <p class="lead">
+        Last updated: February 2026
+      </p>
+
+      <h2>Introduction</h2>
+      <p>
+        The International Society of Phytomedicine (SIPM) is committed to protecting
+        your privacy. This Privacy Policy explains how we collect, use, disclose,
+        and safeguard your information when you visit our website or engage with
+        our services.
+      </p>
+
+      <h2>Information We Collect</h2>
+      <h3>Personal Information</h3>
+      <p>We may collect personal information that you voluntarily provide, including:</p>
+      <ul>
+        <li>Name and contact information (email address, postal address, phone number)</li>
+        <li>Professional affiliations and credentials</li>
+        <li>Membership application details</li>
+        <li>Communications you send to us</li>
+        <li>Payment information for membership fees (processed securely by third-party providers)</li>
+      </ul>
+
+      <h3>Automatically Collected Information</h3>
+      <p>
+        When you visit our website, we may automatically collect certain information,
+        including:
+      </p>
+      <ul>
+        <li>IP address and geographic location</li>
+        <li>Browser type and version</li>
+        <li>Device information</li>
+        <li>Pages visited and time spent on pages</li>
+        <li>Referring website addresses</li>
+      </ul>
+
+      <h2>How We Use Your Information</h2>
+      <p>We use the information we collect to:</p>
+      <ul>
+        <li>Process and manage your membership</li>
+        <li>Communicate with you about standards development, events, and news</li>
+        <li>Provide access to standards and member resources</li>
+        <li>Improve our website and services</li>
+        <li>Comply with legal obligations</li>
+        <li>Protect against fraudulent or unauthorized activity</li>
+      </ul>
+
+      <h2>Information Sharing</h2>
+      <p>
+        We do not sell, trade, or rent your personal information to third parties.
+        We may share your information in the following circumstances:
+      </p>
+      <ul>
+        <li><strong>Service Providers:</strong> With vendors who assist us in operating our website and providing services</li>
+        <li><strong>Legal Requirements:</strong> When required by law or to protect our rights</li>
+        <li><strong>Business Transfers:</strong> In connection with a merger, acquisition, or sale of assets</li>
+        <li><strong>With Your Consent:</strong> When you have given explicit permission</li>
+      </ul>
+
+      <h2>Member Directory</h2>
+      <p>
+        Members may choose to be listed in our public member directory. Participation
+        is optional, and you may opt out at any time by contacting us at
+        <a href="mailto:membership@sipm.org">membership@sipm.org</a>.
+      </p>
+
+      <h2>Data Security</h2>
+      <p>
+        We implement appropriate technical and organizational measures to protect
+        your personal information. However, no method of transmission over the
+        Internet is 100% secure, and we cannot guarantee absolute security.
+      </p>
+
+      <h2>Your Rights</h2>
+      <p>Depending on your location, you may have the right to:</p>
+      <ul>
+        <li>Access the personal information we hold about you</li>
+        <li>Request correction of inaccurate information</li>
+        <li>Request deletion of your personal information</li>
+        <li>Object to or restrict certain processing</li>
+        <li>Request data portability</li>
+        <li>Withdraw consent at any time</li>
+      </ul>
+      <p>
+        To exercise these rights, please contact us at
+        <a href="mailto:privacy@sipm.org">privacy@sipm.org</a>.
+      </p>
+
+      <h2>Cookies</h2>
+      <p>
+        Our website uses cookies to enhance your browsing experience. You can
+        control cookie preferences through your browser settings. Disabling cookies
+        may affect some website functionality.
+      </p>
+
+      <h2>Third-Party Links</h2>
+      <p>
+        Our website may contain links to third-party websites. We are not responsible
+        for the privacy practices of these external sites. We encourage you to read
+        their privacy policies.
+      </p>
+
+      <h2>Children's Privacy</h2>
+      <p>
+        Our services are not directed to individuals under 18 years of age. We do
+        not knowingly collect personal information from children.
+      </p>
+
+      <h2>Changes to This Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. We will notify you of
+        significant changes by posting the new policy on this page and updating the
+        "Last updated" date.
+      </p>
+
+      <h2>Contact Us</h2>
+      <p>
+        If you have questions about this Privacy Policy, please contact us:
+      </p>
+      <ul>
+        <li>Email: <a href="mailto:privacy@sipm.org">privacy@sipm.org</a></li>
+        <li>Address: International Society of Phytomedicine</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useSeo } from '@/composables/useSeo.js'
+
+useSeo({
+  title: 'Privacy Policy',
+  description: 'SIPM Privacy Policy - How we collect, use, and protect your personal information.',
+  url: '/privacy'
+})
+</script>
+
+<style scoped>
+.content-page {
+  max-width: 800px;
+}
+
+.page-title {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-xl);
+}
+
+.content-body {
+  line-height: var(--line-height-relaxed);
+}
+
+.content-body h2 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-2xl);
+  margin-bottom: var(--spacing-md);
+}
+
+.content-body h3 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+.lead {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-light);
+  margin-bottom: var(--spacing-xl);
+}
+
+.content-body ul {
+  margin: var(--spacing-md) 0;
+  padding-left: var(--spacing-xl);
+}
+
+.content-body li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.content-body a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+</style>

--- a/src/views/TermsView.vue
+++ b/src/views/TermsView.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="content-page">
+    <h1 class="page-title">Terms of Use</h1>
+
+    <div class="content-body">
+      <p class="lead">
+        Last updated: February 2026
+      </p>
+
+      <h2>Agreement to Terms</h2>
+      <p>
+        By accessing or using the International Society of Phytomedicine (SIPM)
+        website and services, you agree to be bound by these Terms of Use. If you
+        do not agree to these terms, please do not use our website or services.
+      </p>
+
+      <h2>Description of Services</h2>
+      <p>
+        SIPM provides standards development, publication, and related services
+        for the phytomedicine community. Our services include access to standards
+        documents, membership programs, working group participation, and
+        educational resources.
+      </p>
+
+      <h2>User Accounts</h2>
+      <h3>Registration</h3>
+      <p>
+        To access certain features, you may need to create an account or become
+        a member. You agree to provide accurate, current, and complete information
+        during registration and to update such information as necessary.
+      </p>
+
+      <h3>Account Security</h3>
+      <p>
+        You are responsible for maintaining the confidentiality of your account
+        credentials and for all activities that occur under your account. You agree
+        to notify us immediately of any unauthorized use of your account.
+      </p>
+
+      <h3>Account Termination</h3>
+      <p>
+        We reserve the right to suspend or terminate your account if you violate
+        these Terms of Use or for any other reason at our discretion.
+      </p>
+
+      <h2>Acceptable Use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use our services for any unlawful purpose</li>
+        <li>Violate any applicable laws or regulations</li>
+        <li>Infringe on the intellectual property rights of others</li>
+        <li>Transmit viruses, malware, or other harmful code</li>
+        <li>Attempt to gain unauthorized access to our systems</li>
+        <li>Interfere with the operation of our services</li>
+        <li>Harass, abuse, or harm other users</li>
+        <li>Use automated systems to access our services without permission</li>
+      </ul>
+
+      <h2>Intellectual Property</h2>
+      <h3>SIPM Content</h3>
+      <p>
+        All content on this website, including text, graphics, logos, and software,
+        is the property of SIPM or its content suppliers and is protected by
+        intellectual property laws.
+      </p>
+
+      <h3>Standards Documents</h3>
+      <p>
+        SIPM standards are published under the Creative Commons Attribution 4.0
+        International License (CC BY 4.0), unless otherwise specified. You may:
+      </p>
+      <ul>
+        <li>Share and adapt the material for any purpose</li>
+        <li>Use the material commercially</li>
+      </ul>
+      <p>
+        Provided you give appropriate credit to SIPM, provide a link to the license,
+        and indicate if changes were made.
+      </p>
+
+      <h3>User Submissions</h3>
+      <p>
+        By submitting content to SIPM (such as comments on draft standards), you
+        grant SIPM a non-exclusive, royalty-free, worldwide license to use,
+        reproduce, and distribute such content for standards development purposes.
+      </p>
+
+      <h2>Membership</h2>
+      <h3>Membership Fees</h3>
+      <p>
+        Membership fees are due annually and are non-refundable except as required
+        by law. We reserve the right to change membership fees with reasonable
+        notice.
+      </p>
+
+      <h3>Membership Benefits</h3>
+      <p>
+        Membership benefits are subject to the terms of your membership tier.
+        Benefits may be modified or discontinued with reasonable notice.
+      </p>
+
+      <h2>Working Groups</h2>
+      <p>
+        Participation in SIPM working groups is subject to additional terms and
+        procedures established by SIPM. Working group participants agree to:
+      </p>
+      <ul>
+        <li>Contribute in good faith to standards development</li>
+        <li>Disclose any conflicts of interest</li>
+        <li>Maintain confidentiality of draft documents until publication</li>
+        <li>Follow SIPM's consensus-based decision-making process</li>
+      </ul>
+
+      <h2>Disclaimer of Warranties</h2>
+      <p>
+        OUR SERVICES AND CONTENT ARE PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY
+        KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED
+        WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+        NON-INFRINGEMENT.
+      </p>
+      <p>
+        SIPM DOES NOT WARRANT THAT OUR SERVICES WILL BE UNINTERRUPTED, ERROR-FREE,
+        OR FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+      </p>
+
+      <h2>Limitation of Liability</h2>
+      <p>
+        TO THE MAXIMUM EXTENT PERMITTED BY LAW, SIPM SHALL NOT BE LIABLE FOR ANY
+        INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY
+        LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR
+        ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES.
+      </p>
+
+      <h2>Indemnification</h2>
+      <p>
+        You agree to indemnify and hold harmless SIPM, its officers, directors,
+        employees, and agents from any claims, damages, losses, or expenses
+        arising from your use of our services or violation of these Terms.
+      </p>
+
+      <h2>Governing Law</h2>
+      <p>
+        These Terms of Use shall be governed by and construed in accordance with
+        the laws of the State of Delaware, United States, without regard to its
+        conflict of law provisions.
+      </p>
+
+      <h2>Dispute Resolution</h2>
+      <p>
+        Any disputes arising from these Terms of Use shall be resolved through
+        binding arbitration in accordance with the rules of the American Arbitration
+        Association. The arbitration shall take place in Wilmington, Delaware.
+      </p>
+
+      <h2>Changes to Terms</h2>
+      <p>
+        We may modify these Terms of Use at any time. We will notify users of
+        material changes by posting the updated terms on this page. Your continued
+        use of our services after changes become effective constitutes acceptance
+        of the new terms.
+      </p>
+
+      <h2>Severability</h2>
+      <p>
+        If any provision of these Terms of Use is found to be unenforceable, the
+        remaining provisions shall continue in full force and effect.
+      </p>
+
+      <h2>Contact Us</h2>
+      <p>
+        If you have questions about these Terms of Use, please contact us:
+      </p>
+      <ul>
+        <li>Email: <a href="mailto:legal@sipm.org">legal@sipm.org</a></li>
+        <li>Address: International Society of Phytomedicine</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useSeo } from '@/composables/useSeo.js'
+
+useSeo({
+  title: 'Terms of Use',
+  description: 'SIPM Terms of Use - Terms and conditions for using our website and services.',
+  url: '/terms'
+})
+</script>
+
+<style scoped>
+.content-page {
+  max-width: 800px;
+}
+
+.page-title {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-xl);
+}
+
+.content-body {
+  line-height: var(--line-height-relaxed);
+}
+
+.content-body h2 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-2xl);
+  margin-bottom: var(--spacing-md);
+}
+
+.content-body h3 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+.lead {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-light);
+  margin-bottom: var(--spacing-xl);
+}
+
+.content-body ul {
+  margin: var(--spacing-md) 0;
+  padding-left: var(--spacing-xl);
+}
+
+.content-body li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.content-body a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+</style>

--- a/src/views/standards/StandardView.vue
+++ b/src/views/standards/StandardView.vue
@@ -1,0 +1,467 @@
+<template>
+  <div class="standard-page">
+    <div class="container container-narrow">
+      <TheBreadcrumbs :items="breadcrumbs" />
+
+      <div v-if="loading" class="loading-state">
+        <p>Loading standard...</p>
+      </div>
+
+      <div v-else-if="error" class="error-state glass">
+        <h1>Standard Not Found</h1>
+        <p>{{ error }}</p>
+        <router-link to="/standards" class="back-link">← Back to Standards</router-link>
+      </div>
+
+      <article v-else-if="standard" class="standard">
+        <header class="standard-header">
+          <div class="standard-meta glass">
+            <div class="meta-item">
+              <span class="meta-label">Document Number</span>
+              <span class="meta-value">{{ standard.id }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Edition</span>
+              <span class="meta-value">{{ standard.attributes.edition || '1.0' }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Date</span>
+              <span class="meta-value">{{ formatDate(standard.attributes.revdate) }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Status</span>
+              <Badge :variant="statusVariant">{{ statusText }}</Badge>
+            </div>
+          </div>
+
+          <h1 class="standard-title">{{ standard.title }}</h1>
+
+          <div v-if="standard.attributes.workgroup" class="standard-workgroup">
+            <span>Developed by:</span> {{ standard.attributes.workgroup }}
+          </div>
+        </header>
+
+        <div class="standard-layout">
+          <aside v-if="standard.toc && standard.toc.length > 0" class="standard-toc glass">
+            <h3>Contents</h3>
+            <nav>
+              <ul class="toc-list">
+                <li v-for="section in standard.toc" :key="section.id">
+                  <a :href="`#${section.id}`">{{ section.title }}</a>
+                  <ul v-if="section.children && section.children.length > 0" class="toc-sublist">
+                    <li v-for="child in section.children" :key="child.id">
+                      <a :href="`#${child.id}`">{{ child.title }}</a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </nav>
+          </aside>
+
+          <div class="standard-content" v-html="standard.html"></div>
+        </div>
+
+        <footer class="standard-footer">
+          <div class="footer-actions">
+            <GradientButton variant="gold" @click="downloadPdf">
+              Download PDF
+            </GradientButton>
+            <GradientButton variant="outline" @click="viewOnGithub">
+              View on GitHub
+            </GradientButton>
+          </div>
+        </footer>
+      </article>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import TheBreadcrumbs from '@/components/layout/TheBreadcrumbs.vue'
+import Badge from '@/components/ui/Badge.vue'
+import GradientButton from '@/components/ui/GradientButton.vue'
+import { useSeo } from '@/composables/useSeo.js'
+
+const route = useRoute()
+
+const standard = ref(null)
+const loading = ref(true)
+const error = ref(null)
+
+const standardId = computed(() => route.params.id)
+
+const statusVariant = computed(() => {
+  const stage = standard.value?.attributes?.docstage
+  if (stage === '60') return 'success'
+  if (stage === '40') return 'warning'
+  return 'info'
+})
+
+const statusText = computed(() => {
+  const stage = standard.value?.attributes?.docstage
+  if (stage === '60') return 'Published'
+  if (stage === '40') return 'Draft'
+  if (stage === '30') return 'Committee Draft'
+  return 'Under Development'
+})
+
+const breadcrumbs = computed(() => {
+  const category = route.params.category || 'standards'
+  const categoryNames = {
+    foundation: 'Foundation',
+    quality: 'Quality',
+    science: 'Science',
+    governance: 'Governance'
+  }
+
+  return [
+    { label: 'Standards', path: '/standards' },
+    { label: categoryNames[category] || 'Standards', path: `/standards/${category}` },
+    { label: standard.value?.id || standardId.value, path: route.path }
+  ]
+})
+
+function formatDate(dateStr) {
+  if (!dateStr) return 'TBD'
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function downloadPdf() {
+  // TODO: Implement PDF download
+  alert('PDF download will be available once the standard is finalized.')
+}
+
+function viewOnGithub() {
+  window.open(`https://github.com/sipmorg/standards/tree/main/${standardId.value}`, '_blank')
+}
+
+async function loadStandard() {
+  loading.value = true
+  error.value = null
+
+  try {
+    // Try to load from pre-built content first
+    const response = await fetch(`/content/standards/${standardId.value}.json`)
+
+    if (!response.ok) {
+      // Try GitHub API as fallback
+      const githubResponse = await fetch(
+        `https://api.github.com/repos/sipmorg/standards/contents/${standardId.value}/document.adoc`,
+        {
+          headers: { Accept: 'application/vnd.github.v3.raw' }
+        }
+      )
+
+      if (!githubResponse.ok) {
+        throw new Error('Standard not found')
+      }
+
+      // For GitHub raw content, we'd need to parse it
+      // For now, show a message
+      error.value = 'This standard is available on GitHub but not yet rendered for web viewing.'
+      loading.value = false
+      return
+    }
+
+    standard.value = await response.json()
+  } catch (err) {
+    error.value = err.message || 'Failed to load standard'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadStandard)
+
+useSeo({
+  title: computed(() => standard.value?.title || 'Loading Standard'),
+  description: computed(() => standard.value?.attributes?.['title-intro-en'] || 'SIPM Standard'),
+  url: computed(() => route.path)
+})
+</script>
+
+<style scoped>
+.standard-page {
+  padding: var(--spacing-xl) 0 var(--spacing-3xl);
+}
+
+.loading-state,
+.error-state {
+  text-align: center;
+  padding: var(--spacing-2xl);
+}
+
+.error-state h1 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-2xl);
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-md);
+}
+
+.back-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  display: inline-block;
+  margin-top: var(--spacing-lg);
+}
+
+.standard-header {
+  margin-bottom: var(--spacing-xl);
+}
+
+.standard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.meta-label {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-light);
+}
+
+.meta-value {
+  font-weight: var(--font-weight-medium);
+}
+
+.standard-title {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  line-height: var(--line-height-tight);
+  margin-bottom: var(--spacing-md);
+}
+
+.standard-workgroup {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-light);
+}
+
+.standard-workgroup span {
+  font-weight: var(--font-weight-medium);
+}
+
+.standard-layout {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: var(--spacing-xl);
+}
+
+.standard-toc {
+  padding: var(--spacing-lg);
+  height: fit-content;
+  position: sticky;
+  top: var(--spacing-xl);
+}
+
+.standard-toc h3 {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-light);
+  margin: 0 0 var(--spacing-md);
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-list li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.toc-list a {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.toc-list a:hover {
+  color: var(--color-primary);
+}
+
+.toc-sublist {
+  list-style: none;
+  padding-left: var(--spacing-md);
+  margin-top: var(--spacing-xs);
+}
+
+.toc-sublist a {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-light);
+}
+
+.standard-content {
+  line-height: var(--line-height-relaxed);
+}
+
+.standard-footer {
+  margin-top: var(--spacing-2xl);
+  padding-top: var(--spacing-xl);
+  border-top: 1px solid var(--color-border);
+}
+
+.footer-actions {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 1024px) {
+  .standard-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .standard-toc {
+    position: static;
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .standard-meta {
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .footer-actions {
+    flex-direction: column;
+  }
+}
+</style>
+
+<style>
+/* Global styles for AsciiDoc content */
+.standard-content h1 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-2xl);
+  margin-bottom: var(--spacing-lg);
+}
+
+.standard-content h2 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-md);
+}
+
+.standard-content h3 {
+  font-family: var(--font-serif);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+.standard-content p {
+  margin-bottom: var(--spacing-md);
+}
+
+.standard-content ul,
+.standard-content ol {
+  margin: var(--spacing-md) 0;
+  padding-left: var(--spacing-xl);
+}
+
+.standard-content li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.standard-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--spacing-lg) 0;
+}
+
+.standard-content th,
+.standard-content td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.standard-content th {
+  background: var(--color-glass-dark);
+  font-weight: var(--font-weight-semibold);
+}
+
+.standard-content tr:nth-child(even) td {
+  background: var(--color-glass);
+}
+
+.standard-content pre {
+  background: var(--color-glass-dark);
+  padding: var(--spacing-md);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin: var(--spacing-lg) 0;
+}
+
+.standard-content code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.standard-content blockquote {
+  border-left: 4px solid var(--color-accent);
+  padding-left: var(--spacing-md);
+  margin: var(--spacing-lg) 0;
+  color: var(--color-text-light);
+  font-style: italic;
+}
+
+.standard-content .admonitionblock {
+  padding: var(--spacing-md);
+  margin: var(--spacing-lg) 0;
+  border-radius: var(--radius-md);
+  background: var(--color-glass);
+}
+
+.standard-content .admonitionblock.note {
+  border-left: 4px solid var(--color-info, #3498db);
+}
+
+.standard-content .admonitionblock.warning {
+  border-left: 4px solid var(--color-warning, #f39c12);
+}
+
+.standard-content .admonitionblock.important {
+  border-left: 4px solid var(--color-error, #e74c3c);
+}
+
+.standard-content a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.standard-content .exampleblock {
+  background: var(--color-glass);
+  padding: var(--spacing-md);
+  margin: var(--spacing-lg) 0;
+  border-radius: var(--radius-md);
+}
+</style>


### PR DESCRIPTION
## Summary

This PR adds AsciiDoc rendering capability for standards and includes legal pages for the SIPM website.

### Changes

- **Legal Pages**
  - Added Privacy Policy page (`/privacy`)
  - Added Terms of Use page (`/terms`)

- **AsciiDoc Rendering**
  - Created `scripts/build-standards.js` to convert AsciiDoc standards to JSON
  - Created `StandardView.vue` component for rendering standards with existing design system
  - Standards are served as JSON from `/content/standards/`

- **GitHub Workflow**
  - Updated deploy workflow to checkout `sipmorg/standards` repository
  - Standards JSON is generated during build from the AsciiDoc sources
  - Build supports `STANDARDS_PATH` environment variable for CI

- **Router Updates**
  - Added routes for `/privacy`, `/terms`, and `/standards/:category/:id`

### Standards JSON Structure

Each standard is converted to JSON with:
- `id`: Standard identifier (e.g., "SIPM-0001")
- `title`: Standard title
- `attributes`: Document metadata (edition, date, status, etc.)
- `html`: Full HTML content rendered from AsciiDoc
- `toc`: Table of contents with section hierarchy

### Included Standards

- SIPM-0001: Terminology for Phytomedicine (35+ terms)
- SIPM-0002: Medicinal Fungi Taxonomy
- SIPM-0200: Agricultural Practices for Medicinal Plants
- SIPM-0300: Analytical Methods for Phytomedicine
- SIPM-0400: Clinical Evidence for Phytomedicine

## Test Plan

- [ ] Build site locally: `npm run build`
- [ ] Verify `/privacy` and `/terms` pages render correctly
- [ ] Verify standards JSON is generated in `public/content/standards/`
- [ ] Verify CI workflow checks out standards repo and builds correctly